### PR TITLE
[PR] Correct the array_unshift() parameters order within the public method callSnippets.

### DIFF
--- a/classes/Foolz/SphinxQL/SphinxQL.php
+++ b/classes/Foolz/SphinxQL/SphinxQL.php
@@ -418,8 +418,8 @@ class SphinxQL
      */
     public function callSnippets($data, $index, $extra = array())
     {
-        array_unshift($index, $extra);
-        array_unshift($data, $extra);
+        array_unshift($extra, $index);
+        array_unshift($extra, $data);
 
         return $this->getConnection()->query('CALL SNIPPETS('.implode(', ', $this->getConnection()->quoteArr($extra)).')');
     }


### PR DESCRIPTION
http://us2.php.net/manual/en/function.array-unshift.php
