### PR TITLE
Support for matching against multiple (or all) fulltext fields

### DIFF
--- a/classes/Foolz/SphinxQL/SphinxQL.php
+++ b/classes/Foolz/SphinxQL/SphinxQL.php
@@ -547,7 +547,7 @@ class SphinxQL
         if ( ! empty($this->match)) {
             $query .= 'WHERE MATCH(';
 
-            $matched = [];
+            $matched = array();
 
             foreach ($this->match as $match) {
                 $pre = '';
@@ -931,6 +931,10 @@ class SphinxQL
      */
     public function match($column, $value, $half = false)
     {
+        if ($column === '*' || (is_array($column) && in_array('*', $column))) {
+            $column = array();
+        }
+
         $this->match[] = array('column' => $column, 'value' => $value, 'half' => $half);
 
         return $this;


### PR DESCRIPTION
Fixes #11

Adds support for the following syntax:

``` php
// Specific fields:
$select->match(array('column1', 'column2'), 'words');

// All fulltext fields:
$select->match('*',  'words');
$select->match(/* falsy */, 'words');
```

Apologies, I wasn't able to check against your test cases due to some incompatibility in the Sphinx config file. What version of Sphinx are you running? I'd be happy to look into that further if I knew how to get that RT index working (I am on `2.1.4-release`).

That said, the changes are minimal and they appear to work as expected.
