### PR TITLE
Fix 502 proxy error

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -155,6 +155,13 @@ class Connection implements ConnectionInterface
             throw new ConnectionException('Connection Error: ['.$conn->connect_errno.']'
                 .$conn->connect_error);
         }
+        
+        /**
+         * Add charset so that real_excape_string could work
+         * 
+         * @link http://php.net/manual/en/mysqli.real-escape-string.php
+         */
+        $conn->set_charset("utf8");
 
         $this->connection = $conn;
 


### PR DESCRIPTION
According to this, the charset should be set before calling the $mysqli->real_escape_string('...').

The encoding was missing, which is why real_escape_string was failing.

Simply adding $this->getConnection()->set_charset("utf8"); Solves the problem.
