### PR TITLE
Improve ability of halfEscapeMatch() to fix potential negation and alternation errors

### DIFF
--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -1368,9 +1368,15 @@ class SphinxQL
             $string .= '"';
         }
 
+        $string = preg_replace('/-[\s-]*-/u', '-', $string);
+
         $from_to_preg = array(
-            "'\"([^\s]+)-([^\s]*)\"'" => "\\1\-\\2",
-            "'([^\s]+)-([^\s]*)'" => "\"\\1\-\\2\""
+            '/([-|])\s*$/u' => '\\\\\1',
+            '/\|[\s|]*\|/u' => '|',
+
+            // prevent accidental negation in natural language
+            '/(\S+)-(\S+)/u'       => '\1\-\2',
+            '/(\S+)\s+-\s+(\S+)/u' => '\1 \- \2',
         );
 
         $string = mb_strtolower(preg_replace(array_keys($from_to_preg), array_values($from_to_preg), $string));

--- a/tests/classes/SphinxQLTest.php
+++ b/tests/classes/SphinxQLTest.php
@@ -393,6 +393,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
     public function testHalfEscapeMatch()
     {
         $this->assertSame('this maybe that\^32 and | hi', SphinxQL::create($this->conn)->halfEscapeMatch('this MAYBE that^32 and | hi'));
+        $this->assertSame('this \- not -that | hi \-', SphinxQL::create($this->conn)->halfEscapeMatch('this -- not -that | | hi -'));
         $this->assertSame('stärkergradig | mb', SphinxQL::create($this->conn)->halfEscapeMatch('stärkergradig | mb'));
     }
 


### PR DESCRIPTION
In response to #31.
