### PR TITLE
user utf8 in mb_ func

### DIFF
--- a/src/Drivers/SimpleConnection.php
+++ b/src/Drivers/SimpleConnection.php
@@ -30,13 +30,6 @@ class SimpleConnection implements ConnectionInterface
     protected $connection_params = array('host' => '127.0.0.1', 'port' => 9306, 'socket' => null);
 
     /**
-     * Internal Encoding
-     *
-     * @var string
-     */
-    protected $internal_encoding = null;
-
-    /**
      * Disables any warning outputs returned on the \MySQLi connection with @ prefix.
      *
      * @var boolean
@@ -106,16 +99,6 @@ class SimpleConnection implements ConnectionInterface
     }
 
     /**
-     * Returns the internal encoding.
-     *
-     * @return string current multibyte internal encoding
-     */
-    public function getInternalEncoding()
-    {
-        return $this->internal_encoding;
-    }
-
-    /**
      * Returns the current \mysqli connection established.
      *
      *
@@ -163,7 +146,6 @@ class SimpleConnection implements ConnectionInterface
 
         $conn->set_charset('utf8');
         $this->connection = $conn;
-        $this->mbPush();
 
         return true;
     }
@@ -189,7 +171,6 @@ class SimpleConnection implements ConnectionInterface
      */
     public function close()
     {
-        $this->mbPop();
         $this->getConnection()->close();
         $this->connection = null;
     }
@@ -393,25 +374,4 @@ class SimpleConnection implements ConnectionInterface
         return $result;
     }
 
-    /**
-     * Enter UTF-8 multi-byte workaround mode.
-     */
-    public function mbPush()
-    {
-        $this->internal_encoding = mb_internal_encoding();
-        mb_internal_encoding('UTF-8');
-
-        return $this;
-    }
-
-    /**
-     * Exit UTF-8 multi-byte workaround mode.
-     */
-    public function mbPop()
-    {
-        mb_internal_encoding($this->internal_encoding);
-        $this->internal_encoding = null;
-
-        return $this;
-    }
 }

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -1219,7 +1219,7 @@ class SphinxQL
             return $string->value();
         }
 
-        return mb_strtolower(str_replace(array_keys($this->escape_full_chars), array_values($this->escape_full_chars), $string));
+        return mb_strtolower(str_replace(array_keys($this->escape_full_chars), array_values($this->escape_full_chars), $string), 'utf8');
     }
 
     /**
@@ -1240,7 +1240,7 @@ class SphinxQL
         $string = str_replace(array_keys($this->escape_half_chars), array_values($this->escape_half_chars), $string);
 
         // this manages to lower the error rate by a lot
-        if (mb_substr_count($string, '"') % 2 !== 0) {
+        if (mb_substr_count($string, '"', 'utf8') % 2 !== 0) {
             $string .= '"';
         }
 
@@ -1253,7 +1253,7 @@ class SphinxQL
             '/(\S+)\s+-\s+(\S+)/u' => '\1 \- \2',
         );
 
-        $string = mb_strtolower(preg_replace(array_keys($from_to_preg), array_values($from_to_preg), $string));
+        $string = mb_strtolower(preg_replace(array_keys($from_to_preg), array_values($from_to_preg), $string), 'utf8');
 
         return $string;
     }

--- a/tests/classes/ConnectionTest.php
+++ b/tests/classes/ConnectionTest.php
@@ -219,15 +219,4 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testMbPush()
-    {
-        $this->connection->mbPush();
-        $this->assertEquals('UTF-8', $this->connection->getInternalEncoding());
-    }
-
-    public function testMbPop()
-    {
-        $this->connection->mbPush()->mbPop();
-        $this->assertEquals(null, $this->connection->getInternalEncoding());
-    }
 }


### PR DESCRIPTION
remove mbpush
use utf8 in mb_ functions

because in some place mb_ funcions runs before mbpush