### PR TITLE
Add support of HAVING

### DIFF
--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -1385,6 +1385,7 @@ class SphinxQL
         $this->match = array();
         $this->group_by = array();
         $this->within_group_order_by = array();
+        $this->having = array();
         $this->order_by = array();
         $this->offset = null;
         $this->into = null;
@@ -1420,6 +1421,13 @@ class SphinxQL
     public function resetWithinGroupOrderBy()
     {
         $this->within_group_order_by = array();
+
+        return $this;
+    }
+
+    public function resetHaving()
+    {
+        $this->having = array();
 
         return $this;
     }

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -90,6 +90,13 @@ class SphinxQL
     protected $within_group_order_by = array();
 
     /**
+     * The list of where and parenthesis, must be inserted in order
+     *
+     * @var array
+     */
+    protected $having = array();
+
+    /**
      * ORDER BY array
      *
      * @var array
@@ -564,6 +571,30 @@ class SphinxQL
             $query .= implode(', ', $order_arr).' ';
         }
 
+        if (!empty($this->having)) {
+            $having = $this->having;
+            $query .= 'HAVING ';
+            if (strtoupper($having['operator']) === 'BETWEEN') {
+                $query .= $this->getConnection()->quoteIdentifier($having['column']);
+                $query .=' BETWEEN ';
+                $query .= $this->getConnection()->quote($having['value'][0]).' AND '
+                    .$this->getConnection()->quote($having['value'][1]).' ';
+            } else {
+                // id can't be quoted!
+                if ($having['column'] === 'id') {
+                    $query .= 'id ';
+                } else {
+                    $query .= $this->getConnection()->quoteIdentifier($having['column']).' ';
+                }
+
+                if (in_array(strtoupper($having['operator']), array('IN', 'NOT IN'), true)) {
+                    $query .= strtoupper($having['operator']).' ('.implode(', ', $this->getConnection()->quoteArr($having['value'])).') ';
+                } else {
+                    $query .= $having['operator'].' '.$this->getConnection()->quote($having['value']).' ';
+                }
+            }
+        }
+
         if (!empty($this->order_by)) {
             $query .= 'ORDER BY ';
 
@@ -1014,6 +1045,48 @@ class SphinxQL
     public function withinGroupOrderBy($column, $direction = null)
     {
         $this->within_group_order_by[] = array('column' => $column, 'direction' => $direction);
+
+        return $this;
+    }
+
+    /**
+     * HAVING clause
+     *
+     * Examples:
+     *    $sq->where('column', 'value');
+     *    // HAVING `column` = 'value'
+     *
+     *    $sq->where('column', '=', 'value');
+     *    // HAVING `column` = 'value'
+     *
+     *    $sq->where('column', '>=', 'value')
+     *    // HAVING `column` >= 'value'
+     *
+     *    $sq->where('column', 'IN', array('value1', 'value2', 'value3'));
+     *    // HAVING `column` IN ('value1', 'value2', 'value3')
+     *
+     *    $sq->where('column', 'BETWEEN', array('value1', 'value2'))
+     *    // HAVING `column` BETWEEN 'value1' AND 'value2'
+     *    // HAVING `example` BETWEEN 10 AND 100
+     *
+     * @param string   $column   The column name
+     * @param string   $operator The operator to use
+     * @param string   $value    The value to check against
+     *
+     * @return SphinxQL The current object
+     */
+    public function having($column, $operator, $value = null)
+    {
+        if ($value === null) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        $this->having = array(
+            'column' => $column,
+            'operator' => $operator,
+            'value' => $value
+        );
 
         return $this;
     }

--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -658,6 +658,8 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             ->resetMatch()
             ->groupBy('gid')
             ->resetGroupBy()
+            ->having('gid', '=', '304')
+            ->resetHaving()
             ->withinGroupOrderBy('id', 'desc')
             ->resetWithinGroupOrderBy()
             ->option('comment', 'this should be quoted')

--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -506,7 +506,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create($this->conn)->select(SphinxQL::expr('count(*) as cnt'))
+        $result = SphinxQL::create(self::$conn)->select(SphinxQL::expr('count(*) as cnt'))
             ->from('rt')
             ->groupBy('gid')
             ->having('cnt', '>', 1)

--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -502,6 +502,20 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('3', $result[3]['count(*)']);
     }
 
+    public function testHaving()
+    {
+        $this->refill();
+
+        $result = SphinxQL::create($this->conn)->select(SphinxQL::expr('count(*) as cnt'))
+            ->from('rt')
+            ->groupBy('gid')
+            ->having('cnt', '>', 1)
+            ->execute();
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('2', $result[1]['cnt']);
+    }
+
     public function testOrderBy()
     {
         $this->refill();


### PR DESCRIPTION
Add support of HAVING in SELECT queries:
$result = SphinxQL::create($this->conn)->select(SphinxQL::expr('count(*) as cnt'))
->from('rt')
->groupBy('gid')
->having('cnt', '>', 1)
->execute();

Sphinx supports HAVING only from 2.2.1.