### PR TITLE
Support associative array for callSnippets() options

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ $result = SphinxQL::create($this->conn)
 * `Helper::create($conn)->showSessionVariables() => 'SHOW SESSION VARIABLES'`
 * `Helper::create($conn)->showGlobalVariables() => 'SHOW GLOBAL VARIABLES'`
 * `Helper::create($conn)->setVariable($name, $value, $global = false)`
-* `Helper::create($conn)->callSnippets($data, $index, $extra = array())`
+* `Helper::create($conn)->callSnippets($data, $index, $query, $options = array())`
 * `Helper::create($conn)->callKeywords($text, $index, $hits = null)`
 * `Helper::create($conn)->describe($index)`
 * `Helper::create($conn)->createFunction($udf_name, $returns, $soname)`

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -200,9 +200,7 @@ class Helper
      */
     public function callSnippets($data, $index, $query, $options = array())
     {
-        array_unshift($options, $query);
-        array_unshift($options, $index);
-        array_unshift($options, $data);
+        array_unshift($options, $data, $index, $query);
 
         $arr = $this->getConnection()->quoteArr($options);
         array_walk(

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -154,7 +154,7 @@ class Helper
      * SET syntax
      *
      * @param string  $name   The name of the variable
-     * @param mixed   $value  The value o the variable
+     * @param mixed   $value  The value of the variable
      * @param boolean $global True if the variable should be global, false otherwise
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
@@ -191,18 +191,30 @@ class Helper
     /**
      * CALL SNIPPETS syntax
      *
-     * @param string $data
+     * @param string $data    The document text (or documents) to search
      * @param string $index
-     * @param array  $extra
+     * @param string $query   Search query used for highlighting
+     * @param array  $options Associative array of additional options
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
      */
-    public function callSnippets($data, $index, $extra = array())
+    public function callSnippets($data, $index, $query, $options = array())
     {
-        array_unshift($extra, $index);
-        array_unshift($extra, $data);
+        array_unshift($options, $query);
+        array_unshift($options, $index);
+        array_unshift($options, $data);
 
-        return $this->query('CALL SNIPPETS('.implode(', ', $this->getConnection()->quoteArr($extra)).')');
+        $arr = $this->getConnection()->quoteArr($options);
+        array_walk(
+            $arr,
+            function (&$val, $key) {
+                if (is_string($key)) {
+                    $val = $val.' AS '.$key;
+                }
+            }
+        );
+
+        return $this->query('CALL SNIPPETS('.implode(', ', $arr).')');
     }
 
     /**

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,6 @@ Make sure there's a `data` directory under the `tests` directory.
 
 There are a few functions not comprehended in the unit testing.
 
-* `callSnippets`
 * `callKeywords`
 * `createFunction`
 * `dropFunction`

--- a/tests/SphinxQL/HelperTest.php
+++ b/tests/SphinxQL/HelperTest.php
@@ -56,4 +56,46 @@ class HelperTest extends PHPUnit_Framework_TestCase
         Helper::create($this->conn)->setVariable('@foo', 1, true);
         Helper::create($this->conn)->setVariable('@foo', array(0), true);
     }
+
+    public function testCallSnippets()
+    {
+        $snippets = Helper::create($this->conn)->callSnippets(
+            'this is my document text',
+            'rt',
+            'is'
+        )->execute()->getStored();
+        $this->assertEquals(
+            array(array('snippet' => 'this <b>is</b> my document text')),
+            $snippets
+        );
+
+        $snippets = Helper::create($this->conn)->callSnippets(
+            'this is my document text',
+            'rt',
+            'is',
+            array(
+                'query_mode'   => 1,
+                'before_match' => '<em>',
+                'after_match'  => '</em>',
+            )
+        )->execute()->getStored();
+        $this->assertEquals(
+            array(array('snippet' => 'this <em>is</em> my document text')),
+            $snippets
+        );
+
+        $snippets = Helper::create($this->conn)->callSnippets(
+            array('this is my document text', 'another document'),
+            'rt',
+            'is',
+            array('allow_empty' => 1)
+        )->execute()->getStored();
+        $this->assertEquals(
+            array(
+                array('snippet' => 'this <b>is</b> my document text'),
+                array('snippet' => ''),
+            ),
+            $snippets
+        );
+    }
 }


### PR DESCRIPTION
```php
// previous syntax
Helper::create($conn)->callSnippets(
    "this is my document text",
    "my_index",
    [
        "is", // why is my search query over here?
        SphinxQL::expr("1 AS query_mode"),
        SphinxQL::expr("'<em>' AS before_match"),
        SphinxQL::expr("'</em>' AS after_match"),
    ]
);

// new syntax
Helper::create($conn)->callSnippets(
    "this is my document text",
    "my_index",
    "is",
    [
        "query_mode"   => 1,
        "before_match" => "<em>",
        "after_match"  => "</em>",
    ]
);
```