### PR TITLE
Fix crash on foreach with empty ResultSet

### DIFF
--- a/src/Drivers/Mysqli/ResultSet.php
+++ b/src/Drivers/Mysqli/ResultSet.php
@@ -415,7 +415,9 @@ class ResultSet implements ResultSetInterface
      */
     public function rewind()
     {
-        $this->toRow(0);
+        if ($this->getCount()) {
+            $this->toRow(0);
+        }
     }
 
     /**

--- a/src/Drivers/Pdo/ResultSet.php
+++ b/src/Drivers/Pdo/ResultSet.php
@@ -399,7 +399,9 @@ class ResultSet implements ResultSetInterface
      */
     public function rewind()
     {
-        $this->toRow(0);
+        if ($this->getCount()) {
+            $this->toRow(0);
+        }
     }
 
     /**

--- a/tests/SphinxQL/ResultSetTest.php
+++ b/tests/SphinxQL/ResultSetTest.php
@@ -245,7 +245,7 @@ class ResultSetTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expect[0], $array[0]);
         $this->assertSame($expect[1], $array[1]);
 
-        $emptyRes = self::$conn->query('SELECT * FROM rt WHERE id = 404');
+        $res = self::$conn->query('SELECT * FROM rt WHERE id = 404');
         $array = array();
         foreach ($res as $key => $value) {
             $array[$key] = $value;

--- a/tests/SphinxQL/ResultSetTest.php
+++ b/tests/SphinxQL/ResultSetTest.php
@@ -244,5 +244,12 @@ class ResultSetTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expect[0], $array[0]);
         $this->assertSame($expect[1], $array[1]);
+
+        $emptyRes = self::$conn->query('SELECT * FROM rt WHERE id = 404');
+        $array = array();
+        foreach ($res as $key => $value) {
+            $array[$key] = $value;
+        }
+        $this->assertEmpty($array);
     }
 }


### PR DESCRIPTION
Cannot rewind to row 0 if no rows were retrieved.