### PR TITLE
SphinxQL::create() will return an instance of the object which was called

### DIFF
--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -221,7 +221,7 @@ class SphinxQL
      */
     public static function create(ConnectionInterface $connection)
     {
-        return new SphinxQL($connection);
+        return new static($connection);
     }
 
     /**


### PR DESCRIPTION
This is helpful when extending the class. We kinda had to override the create method in our own usage.