### PR TITLE
#80 skip quoting columns/fields with backticks

### DIFF
--- a/src/Drivers/ConnectionBase.php
+++ b/src/Drivers/ConnectionBase.php
@@ -97,17 +97,7 @@ abstract class ConnectionBase implements ConnectionInterface
             return $value->value();
         }
 
-        if ($value === '*') {
-            return $value;
-        }
-
-        $pieces = explode('.', $value);
-
-        foreach ($pieces as $key => $piece) {
-            $pieces[$key] = '`'.$piece.'`';
-        }
-
-        return implode('.', $pieces);
+        return $value;
     }
 
     /**

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -239,7 +239,7 @@ class SphinxQL
      *
      * Examples:
      *    $query->where('time', '>', SphinxQL::expr('CURRENT_TIMESTAMP'));
-     *    // WHERE `time` > CURRENT_TIMESTAMP
+     *    // WHERE time > CURRENT_TIMESTAMP
      *
      * @param string $string The string to keep unaltered
      *
@@ -915,20 +915,20 @@ class SphinxQL
      *
      * Examples:
      *    $query->where('column', 'value');
-     *    // WHERE `column` = 'value'
+     *    // WHERE column = 'value'
      *
      *    $query->where('column', '=', 'value');
-     *    // WHERE `column` = 'value'
+     *    // WHERE column = 'value'
      *
      *    $query->where('column', '>=', 'value')
-     *    // WHERE `column` >= 'value'
+     *    // WHERE column >= 'value'
      *
      *    $query->where('column', 'IN', array('value1', 'value2', 'value3'));
-     *    // WHERE `column` IN ('value1', 'value2', 'value3')
+     *    // WHERE column IN ('value1', 'value2', 'value3')
      *
      *    $query->where('column', 'BETWEEN', array('value1', 'value2'))
-     *    // WHERE `column` BETWEEN 'value1' AND 'value2'
-     *    // WHERE `example` BETWEEN 10 AND 100
+     *    // WHERE column BETWEEN 'value1' AND 'value2'
+     *    // WHERE example BETWEEN 10 AND 100
      *
      * @param string   $column   The column name
      * @param string   $operator The operator to use
@@ -989,20 +989,20 @@ class SphinxQL
      *
      * Examples:
      *    $sq->having('column', 'value');
-     *    // HAVING `column` = 'value'
+     *    // HAVING column = 'value'
      *
      *    $sq->having('column', '=', 'value');
-     *    // HAVING `column` = 'value'
+     *    // HAVING column = 'value'
      *
      *    $sq->having('column', '>=', 'value')
-     *    // HAVING `column` >= 'value'
+     *    // HAVING column >= 'value'
      *
      *    $sq->having('column', 'IN', array('value1', 'value2', 'value3'));
-     *    // HAVING `column` IN ('value1', 'value2', 'value3')
+     *    // HAVING column IN ('value1', 'value2', 'value3')
      *
      *    $sq->having('column', 'BETWEEN', array('value1', 'value2'))
-     *    // HAVING `column` BETWEEN 'value1' AND 'value2'
-     *    // HAVING `example` BETWEEN 10 AND 100
+     *    // HAVING column BETWEEN 'value1' AND 'value2'
+     *    // HAVING example BETWEEN 10 AND 100
      *
      * @param string   $column   The column name
      * @param string   $operator The operator to use

--- a/tests/SphinxQL/ConnectionTest.php
+++ b/tests/SphinxQL/ConnectionTest.php
@@ -202,26 +202,6 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         $this->connection->escape('\' "" \'\' ');
     }
 
-    public function testQuoteIdentifier()
-    {
-        // test *
-        $this->assertEquals('*', $this->connection->quoteIdentifier('*'));
-
-        // test a normal string
-        $this->assertEquals('`foo`.`bar`', $this->connection->quoteIdentifier('foo.bar'));
-
-        // test a SphinxQLExpression
-        $this->assertEquals('foo.bar', $this->connection->quoteIdentifier(new Expression('foo.bar')));
-    }
-
-    public function testQuoteIdentifierArr()
-    {
-        $this->assertSame(
-            array('*', '`foo`.`bar`', 'foo.bar'),
-            $this->connection->quoteIdentifierArr(array('*', 'foo.bar', new Expression('foo.bar')))
-        );
-    }
-
     public function testQuote()
     {
         $this->connection->connect();

--- a/tests/SphinxQL/FacetTest.php
+++ b/tests/SphinxQL/FacetTest.php
@@ -43,31 +43,31 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->facet(array('gid'))
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`', $facet);
+        $this->assertEquals('FACET gid', $facet);
 
         $facet = Facet::create(self::$conn)
             ->facet(array('gid', 'title', 'content'))
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title`, `content`', $facet);
+        $this->assertEquals('FACET gid, title, content', $facet);
 
         $facet = Facet::create(self::$conn)
             ->facet('gid', 'title', 'content')
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title`, `content`', $facet);
+        $this->assertEquals('FACET gid, title, content', $facet);
 
         $facet = Facet::create(self::$conn)
             ->facet(array('aliAS' => 'gid'))
             ->getFacet();
 
-        $this->assertEquals('FACET `gid` AS aliAS', $facet);
+        $this->assertEquals('FACET gid AS aliAS', $facet);
 
         $facet = Facet::create(self::$conn)
             ->facet(array('gid', 'name' => 'title', 'content'))
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title` AS name, `content`', $facet);
+        $this->assertEquals('FACET gid, title AS name, content', $facet);
 
         $facet = new Facet();
         $facet = $facet
@@ -75,7 +75,7 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->facet('gid', array('name' => 'title'), 'content')
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title` AS name, `content`', $facet);
+        $this->assertEquals('FACET gid, title AS name, content', $facet);
     }
 
     public function testFacetFunction()
@@ -100,7 +100,7 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->by('gid')
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title`, `content` BY `gid`', $facet);
+        $this->assertEquals('FACET gid, title, content BY gid', $facet);
     }
 
     public function testOrderBy()
@@ -110,7 +110,7 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->orderBy('gid', 'DESC')
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title` ORDER BY `gid` DESC', $facet);
+        $this->assertEquals('FACET gid, title ORDER BY gid DESC', $facet);
 
         $facet = Facet::create(self::$conn)
             ->facet(array('gid', 'content'))
@@ -118,7 +118,7 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->orderBy('content', 'DESC')
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `content` ORDER BY `gid` ASC, `content` DESC', $facet);
+        $this->assertEquals('FACET gid, content ORDER BY gid ASC, content DESC', $facet);
     }
 
     public function testOrderByFunction()
@@ -128,7 +128,7 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->orderByFunction('COUNT','*', 'DESC')
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title` ORDER BY COUNT(*) DESC', $facet);
+        $this->assertEquals('FACET gid, title ORDER BY COUNT(*) DESC', $facet);
     }
 
     public function testLimit()
@@ -139,6 +139,6 @@ class FacetTest  extends PHPUnit_Framework_TestCase
             ->limit(5, 5)
             ->getFacet();
 
-        $this->assertEquals('FACET `gid`, `title` ORDER BY COUNT(*) DESC LIMIT 5, 5', $facet);
+        $this->assertEquals('FACET gid, title ORDER BY COUNT(*) DESC LIMIT 5, 5', $facet);
     }
 }

--- a/tests/SphinxQL/HelperTest.php
+++ b/tests/SphinxQL/HelperTest.php
@@ -179,9 +179,9 @@ class HelperTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('SHOW STATUS', $query->compile()->getCompiled());
 
         $query = Helper::create($this->conn)->attachIndex('disk', 'rt');
-        $this->assertEquals('ATTACH INDEX `disk` TO RTINDEX `rt`', $query->compile()->getCompiled());
+        $this->assertEquals('ATTACH INDEX disk TO RTINDEX rt', $query->compile()->getCompiled());
 
         $query = Helper::create($this->conn)->flushRtIndex('rt');
-        $this->assertEquals('FLUSH RTINDEX `rt`', $query->compile()->getCompiled());
+        $this->assertEquals('FLUSH RTINDEX rt', $query->compile()->getCompiled());
     }
 }

--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -574,7 +574,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             ->compile()
             ->getCompiled();
 
-        $this->assertEquals('SELECT * FROM `rt` OPTION `comment` = \'this should be quoted\'', $result);
+        $this->assertEquals('SELECT * FROM rt OPTION comment = \'this should be quoted\'', $result);
 
         $result = SphinxQL::create(self::$conn)->select()
             ->from('rt')
@@ -582,7 +582,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             ->compile()
             ->getCompiled();
 
-        $this->assertEquals('SELECT * FROM `rt` OPTION `field_weights` = (content=50)', $result);
+        $this->assertEquals('SELECT * FROM rt OPTION field_weights = (content=50)', $result);
 
         $result = SphinxQL::create(self::$conn)->select()
             ->from('rt')
@@ -594,7 +594,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             ->compile()
             ->getCompiled();
 
-        $this->assertEquals('SELECT * FROM `rt` OPTION `field_weights` = (title=80, content=35, tags=92)', $result);
+        $this->assertEquals('SELECT * FROM rt OPTION field_weights = (title=80, content=35, tags=92)', $result);
     }
 
     public function testGroupBy()
@@ -800,7 +800,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             ->compile()
             ->getCompiled();
 
-        $this->assertEquals('SELECT * FROM `rt`', $result);
+        $this->assertEquals('SELECT * FROM rt', $result);
     }
 
     /**
@@ -860,7 +860,7 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             })
             ->orderBy('id', 'ASC');
         $this->assertEquals(
-            'SELECT * FROM (SELECT `id` FROM `rt` ORDER BY `id` DESC) ORDER BY `id` ASC',
+            'SELECT * FROM (SELECT id FROM rt ORDER BY id DESC) ORDER BY id ASC',
             $query->compile()->getCompiled()
         );
         $result = $query
@@ -879,11 +879,11 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             ->from($subquery)
             ->orderBy('id', 'ASC');
         $this->assertEquals(
-            'SELECT `id` FROM `rt` ORDER BY `id` DESC',
+            'SELECT id FROM rt ORDER BY id DESC',
             $subquery->compile()->getCompiled()
         );
         $this->assertEquals(
-            'SELECT * FROM (SELECT `id` FROM `rt` ORDER BY `id` DESC) ORDER BY `id` ASC',
+            'SELECT * FROM (SELECT id FROM rt ORDER BY id DESC) ORDER BY id ASC',
             $query->compile()->getCompiled()
         );
         $result = $subquery


### PR DESCRIPTION
Since this is a quick hotfix, the `quoteIdentifier` function won't be removed.