### PR TITLE
Switch check to Closure for match and subselect builders, fixes #82

### DIFF
--- a/src/Match.php
+++ b/src/Match.php
@@ -64,7 +64,7 @@ class Match
      *    $match->match($sub);
      *    // (a | b)
      *
-     * @param string|Match|callable $keywords The text or expression to match.
+     * @param string|Match|Closure $keywords The text or expression to match.
      */
     public function match($keywords = null)
     {
@@ -84,7 +84,7 @@ class Match
      *    $match->match('test')->orMatch('case');
      *    // test | case
      *
-     * @param string|Match|callable $keywords The text or expression to alternatively match.
+     * @param string|Match|Closure $keywords The text or expression to alternatively match.
      */
     public function orMatch($keywords = null)
     {
@@ -103,7 +103,7 @@ class Match
      *    $match->match('test')->maybe('case');
      *    // test MAYBE case
      *
-     * @param string|Match|callable $keywords The text or expression to optionally match.
+     * @param string|Match|Closure $keywords The text or expression to optionally match.
      */
     public function maybe($keywords = null)
     {
@@ -267,7 +267,7 @@ class Match
      *    $match->match('test')->before('case');
      *    // test << case
      *
-     * @param string|Match|callable $keywords The text or expression that must come after.
+     * @param string|Match|Closure $keywords The text or expression that must come after.
      */
     public function before($keywords = null)
     {
@@ -329,8 +329,8 @@ class Match
      *    $match->match('test')->near('case', 3);
      *    // test NEAR/3 case
      *
-     * @param string|Match|callable $keywords  The text or expression to match nearby.
-     * @param int                   $distance  Maximum distance to the match.
+     * @param string|Match|Closure $keywords  The text or expression to match nearby.
+     * @param int                  $distance  Maximum distance to the match.
      */
     public function near($keywords, $distance = null)
     {
@@ -351,7 +351,7 @@ class Match
      *    $match->match('test')->sentence('case');
      *    // test SENTENCE case
      *
-     * @param string|Match|callable $keywords The text or expression that must be in the sentence.
+     * @param string|Match|Closure $keywords The text or expression that must be in the sentence.
      */
     public function sentence($keywords = null)
     {
@@ -370,7 +370,7 @@ class Match
      *    $match->match('test')->paragraph('case');
      *    // test PARAGRAPH case
      *
-     * @param string|Match|callable $keywords The text or expression that must be in the paragraph.
+     * @param string|Match|Closure $keywords The text or expression that must be in the paragraph.
      */
     public function paragraph($keywords = null)
     {
@@ -392,8 +392,8 @@ class Match
      *    $match->zone('th', 'test');
      *    // ZONE:(th) test
      *
-     * @param string|array          $zones     The zone or zones to search.
-     * @param string|Match|callable $keywords  The text or expression that must be in these zones.
+     * @param string|array         $zones     The zone or zones to search.
+     * @param string|Match|Closure $keywords  The text or expression that must be in these zones.
      */
     public function zone($zones, $keywords = null)
     {
@@ -416,8 +416,8 @@ class Match
      *    $match->zonespan('th', 'test');
      *    // ZONESPAN:(th) test
      *
-     * @param string                $zone      The zone to search.
-     * @param string|Match|callable $keywords  The text or expression that must be in this zone.
+     * @param string               $zone      The zone to search.
+     * @param string|Match|Closure $keywords  The text or expression that must be in this zone.
      */
     public function zonespan($zone, $keywords = null)
     {
@@ -438,7 +438,7 @@ class Match
                     $query .= $token['MATCH']->value().' ';
                 } elseif ($token['MATCH'] instanceof Match) {
                     $query .= '('.$token['MATCH']->compile()->getCompiled().') ';
-                } elseif (is_callable($token['MATCH'])) {
+                } elseif ($token['MATCH'] instanceof \Closure) {
                     $sub = new static($this->sphinxql);
                     call_user_func($token['MATCH'], $sub);
                     $query .= '('.$sub->compile()->getCompiled().') ';

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -440,7 +440,7 @@ class SphinxQL
 
             foreach ($this->match as $match) {
                 $pre = '';
-                if (is_callable($match['column'])) {
+                if ($match['column'] instanceof \Closure) {
                     $sub = new Match($this);
                     call_user_func($match['column'], $sub);
                     $pre .= $sub->compile()->getCompiled();
@@ -545,7 +545,7 @@ class SphinxQL
         }
 
         if (!empty($this->from)) {
-            if (is_callable($this->from)) {
+            if ($this->from instanceof \Closure) {
                 $sub = new static($this->getConnection());
                 call_user_func($this->from, $sub);
                 $query .= 'FROM ('.$sub->compile()->getCompiled().') ';
@@ -883,7 +883,7 @@ class SphinxQL
             $this->from = \func_get_args();
         }
 
-        if (is_array($array) || is_callable($array) || $array instanceof SphinxQL) {
+        if (is_array($array) || $array instanceof \Closure || $array instanceof SphinxQL) {
             $this->from = $array;
         }
 
@@ -893,7 +893,7 @@ class SphinxQL
     /**
      * MATCH clause (Sphinx-specific)
      *
-     * @param mixed    $column The column name (can be array, string, function, or Match)
+     * @param mixed    $column The column name (can be array, string, Closure, or Match)
      * @param string   $value  The value
      * @param boolean  $half  Exclude ", |, - control characters from being escaped
      *

--- a/tests/SphinxQL/MatchTest.php
+++ b/tests/SphinxQL/MatchTest.php
@@ -297,4 +297,12 @@ class MatchTest extends PHPUnit_Framework_TestCase
             });
         $this->assertEquals('aaa -(bbb -(ccc ddd))', $match->compile()->getCompiled());
     }
+
+    // issue #82
+    public function testClosureMisuse()
+    {
+        $match = Match::create(self::$sphinxql)
+            ->match('strlen');
+        $this->assertEquals('strlen', $match->compile()->getCompiled());
+    }
 }

--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -946,4 +946,26 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('2', $result[1][3]['count(*)']);
         }
     }
+
+    // issue #82
+    public function testClosureMisuse()
+    {
+        $query = SphinxQL::create(self::$conn)
+            ->select()
+            ->from('strlen')
+            ->orderBy('id', 'ASC');
+        $this->assertEquals(
+            'SELECT * FROM strlen ORDER BY id ASC',
+            $query->compile()->getCompiled()
+        );
+
+        $query = SphinxQL::create(self::$conn)
+            ->select()
+            ->from('rt')
+            ->match('strlen', 'value');
+        $this->assertEquals(
+            "SELECT * FROM rt WHERE MATCH('(@strlen value)')",
+            $query->compile()->getCompiled()
+        );
+    }
 }


### PR DESCRIPTION
As pointed out, `is_callable()` is not restrictive enough, and can result in unintended function calls.