### PR TITLE
fix HAVING tests

### DIFF
--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -648,10 +648,10 @@ class SphinxQLTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $result);
         $this->assertEquals('2', $result[1]['cnt']);
 
-        $result = SphinxQL::create(self::$conn)->select(SphinxQL::expr('count(*) as cnt'))
+        $result = SphinxQL::create(self::$conn)->select(SphinxQL::expr('count(*) as cnt'), SphinxQL::expr('GROUPBY() gd'))
             ->from('rt')
             ->groupBy('gid')
-            ->having('gid', 304)
+            ->having('gd', 304)
             ->execute();
 
         $this->assertCount(1, $result);


### PR DESCRIPTION
There was a change to the `HAVING` query in the 2.2.11-release build.

http://sphinxsearch.com/bugs/view.php?id=2399
https://github.com/sphinxsearch/sphinx/commit/0f75f1f