### PR TITLE
update travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,15 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 env:
   - DRIVER=mysqli SPHINXSEARCH_BUILD=rel22
+  - DRIVER=mysqli SPHINXSEARCH_BUILD=rel23
   - DRIVER=mysqli SPHINXSEARCH_BUILD=beta
   - DRIVER=pdo SPHINXSEARCH_BUILD=rel22
+  - DRIVER=pdo SPHINXSEARCH_BUILD=rel23
   - DRIVER=pdo SPHINXSEARCH_BUILD=beta
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: DRIVER=pdo SPHINXSEARCH_BUILD=rel22
+    - env: DRIVER=pdo SPHINXSEARCH_BUILD=rel23
     - env: DRIVER=pdo SPHINXSEARCH_BUILD=beta
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,13 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: DRIVER=pdo SPHINXSEARCH_BUILD=rel22
-    - env: DRIVER=pdo SPHINXSEARCH_BUILD=rel23
-    - env: DRIVER=pdo SPHINXSEARCH_BUILD=beta
+  exclude:
+    - php: 5.3
+      env: DRIVER=pdo SPHINXSEARCH_BUILD=rel22
+    - php: 5.3
+      env: DRIVER=pdo SPHINXSEARCH_BUILD=rel23
+    - php: 5.3
+      env: DRIVER=pdo SPHINXSEARCH_BUILD=beta
 
 before_install:
   - mkdir $HOME/sphinx


### PR DESCRIPTION
This adds the following:

- php 7.1
- sphinxsearch 2.3 (rel23)

Note: `sphinxsearch-rel23` branch doesn't have any builds at the moment.
https://launchpad.net/~builds/+archive/ubuntu/sphinxsearch-rel23