### PR TITLE
Make it more robust for number in string type.

### DIFF
--- a/src/Drivers/ConnectionBase.php
+++ b/src/Drivers/ConnectionBase.php
@@ -103,11 +103,15 @@ abstract class ConnectionBase implements ConnectionInterface
         } elseif ($value instanceof Expression) {
             // Use the raw expression
             return $value->value();
-        } elseif (is_int($value)) {
-            return (int) $value;
-        } elseif (is_float($value)) {
-            // Convert to non-locale aware float to prevent possible commas
-            return sprintf('%F', $value);
+        } elseif (is_numeric($value)) {
+            if (is_int($value)) {
+                return (int) $value;
+            } elseif (is_float($value)) {
+                // Convert to non-locale aware float to prevent possible commas
+                return sprintf('%F', $value);
+            } else {
+                return $value;
+            }
         }  elseif (is_array($value)) {
             // Supports MVA attributes
             return '('.implode(',', $this->quoteArr($value)).')';


### PR DESCRIPTION
When we pass numeric string value to **ConnectionBase::quote** it will be tested by is_int() and is_float() which will return false. So input the value '10' will output "'10'" which can not accept by sphinxQL as uint type unlike mysql.
Meanwhile, in many cases, int/float values are queried from database in string type. So we must convert each int/float string to int/float before send it to ConnectionBase::quote.

Using is_numeric will make thing easier especially for MVA type.