### PR TITLE
fixed argument and return types of methods

### DIFF
--- a/src/Drivers/ConnectionBase.php
+++ b/src/Drivers/ConnectionBase.php
@@ -95,7 +95,8 @@ abstract class ConnectionBase implements ConnectionInterface
      * Adds quotes around values when necessary.
      * Based on FuelPHP's quoting function.
      *
-     * @param Expression|string $value The input string, eventually wrapped in an expression to leave it untouched
+     * @param Expression|string|null|bool|array|int|float $value The input string, eventually wrapped in an expression
+     *      to leave it untouched
      *
      * @return Expression|string|int The untouched Expression or the quoted string
      */

--- a/src/Drivers/ConnectionInterface.php
+++ b/src/Drivers/ConnectionInterface.php
@@ -47,7 +47,8 @@ interface ConnectionInterface
     /**
      * Adds quotes around values when necessary.
      *
-     * @param Expression|string $value The input string, eventually wrapped in an expression to leave it untouched
+     * @param Expression|string|null|bool|array|int|float $value The input string, eventually wrapped in an expression
+     *      to leave it untouched
      *
      * @return Expression|string|int The untouched Expression or the quoted string
      */

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -974,8 +974,9 @@ class SphinxQL
      *    // WHERE example BETWEEN 10 AND 100
      *
      * @param string   $column   The column name
-     * @param string   $operator The operator to use
-     * @param string   $value    The value to check against
+     * @param Expression|string|null|bool|array|int|float $operator The operator to use (if value is not null, you can
+     *      use only string)
+     * @param Expression|string|null|bool|array|int|float $value The value to check against
      *
      * @return SphinxQL
      */
@@ -1141,7 +1142,7 @@ class SphinxQL
      * Used by: SELECT
      *
      * @param string $name  Option name
-     * @param string $value Option value
+     * @param Expression|array|string|int|bool|float|null $value Option value
      *
      * @return SphinxQL
      */


### PR DESCRIPTION
in my project we check types with phpstan, and we call method option with array, but in phpdoc this method accept only string, and this is problem. This method can accept a lot of various types