### PR TITLE
make helper constructor public

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -15,7 +15,7 @@ class Helper
      */
     public $connection;
 
-    protected function __construct(ConnectionInterface $connection)
+    public function __construct(ConnectionInterface $connection)
     {
         $this->connection = $connection;
     }


### PR DESCRIPTION
So I've made Helper constructor public
- to make it depedency container injectable
- if someone wants to override it it won't be nessesery to modify 2 methods starting with static create
- make method create no to be the only way to create the object

PS
php 5.3 became very-very old it is not necessary to support it
that why i suggest to support php 5.4 or higher 
AND drop static method create from SphinxQL, Helper, Match and Facet
and use short syntax (new Foo)->bar();