### PR TITLE
abstract method connect() in ConnectionBase

### DIFF
--- a/src/Drivers/ConnectionBase.php
+++ b/src/Drivers/ConnectionBase.php
@@ -156,6 +156,12 @@ abstract class ConnectionBase implements ConnectionInterface
     }
 
     /**
+     * @param bool $suppress_error
+     * @return bool
+     */
+    abstract public function connect($suppress_error = false);
+
+    /**
      * Forces the connection to suppress all errors returned. This should only be used
      * when the production server is running with high error reporting settings.
      *

--- a/src/Drivers/ConnectionBase.php
+++ b/src/Drivers/ConnectionBase.php
@@ -156,8 +156,12 @@ abstract class ConnectionBase implements ConnectionInterface
     }
 
     /**
-     * @param bool $suppress_error
-     * @return bool
+     * Establishes a connection to the Sphinx server.
+     *
+     * @param bool $suppress_error If the warnings on the connection should be suppressed
+     *
+     * @return bool True if connected
+     * @throws ConnectionException If a connection error was encountered
      */
     abstract public function connect($suppress_error = false);
 

--- a/src/Drivers/Mysqli/Connection.php
+++ b/src/Drivers/Mysqli/Connection.php
@@ -32,12 +32,7 @@ class Connection extends ConnectionBase
     }
 
     /**
-     * Establishes a connection to the Sphinx server with \MySQLi.
-     *
-     * @param boolean $suppress_error If the warnings on the connection should be suppressed
-     *
-     * @return boolean True if connected
-     * @throws ConnectionException If a connection error was encountered
+     * @inheritdoc
      */
     public function connect($suppress_error = false)
     {

--- a/src/Drivers/Pdo/Connection.php
+++ b/src/Drivers/Pdo/Connection.php
@@ -47,8 +47,7 @@ class Connection extends ConnectionBase
     }
 
     /**
-     * @return bool
-     * @throws ConnectionException
+     * @inheritdoc
      */
     public function connect($suppress_error = false)
     {


### PR DESCRIPTION
here \Foolz\SphinxQL\Drivers\ConnectionBase::ensureConnection is calling method connect() which is not defined in class
It is expected that method will be implemented in child classes - so i've made such method abstract in parent class