### PR TITLE
drop static creational methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ __This package is BETA QUALITY.__ It is recommended that you do extensive testin
 
 SphinxQL evolves very fast.
 
-Most of the new functions are static one liners like `SHOW PLUGINS`. We'll avoid trying to keep up with these methods, as they are easy to just call directly (`SphinxQL::create($conn)->query($sql)->execute()`). You're free to submit pull requests to support these methods.
+Most of the new functions are static one liners like `SHOW PLUGINS`. We'll avoid trying to keep up with these methods, as they are easy to just call directly (`(new SphinxQL($conn))->query($sql)->execute()`). You're free to submit pull requests to support these methods.
 
 If any feature is unreachable through this library, open a new issue or send a pull request.
 
@@ -67,7 +67,7 @@ use Foolz\SphinxQL\Connection;
 $conn = new Connection();
 $conn->setParams(array('host' => 'domain.tld', 'port' => 9306));
 
-$query = SphinxQL::create($conn)->select('column_one', 'colume_two')
+$query = (new SphinxQL($conn))->select('column_one', 'colume_two')
     ->from('index_ancient', 'index_main', 'index_delta')
     ->match('comment', 'my opinion is superior to yours')
     ->where('banned', '=', 1);
@@ -98,7 +98,7 @@ _More methods are available in the Connection class, but usually not necessary a
 
 ### SphinxQL
 
-* __SphinxQL::create($conn)__
+* __new SphinxQL($conn)__
 
 	Creates a SphinxQL instance used for generating queries.
 
@@ -138,7 +138,7 @@ There are cases when an input __must__ be escaped in the SQL statement. The foll
 
 #### SELECT
 
-* __$sq = SphinxQL::create($conn)->select($column1, $column2, ...)->from($index1, $index2, ...)__
+* __$sq = (new SphinxQL($conn))->select($column1, $column2, ...)->from($index1, $index2, ...)__
 
 	Begins a `SELECT` query statement. If no column is specified, the statement defaults to using `*`. Both `$column1` and `$index1` can be arrays.
 
@@ -146,11 +146,11 @@ There are cases when an input __must__ be escaped in the SQL statement. The foll
 
 This will return an `INT` with the number of rows affected.
 
-* __$sq = SphinxQL::create($conn)->insert()->into($index)__
+* __$sq = (new SphinxQL($conn))->insert()->into($index)__
 
 	Begins an `INSERT`.
 
-* __$sq = SphinxQL::create($conn)->replace()->into($index)__
+* __$sq = (new SphinxQL($conn))->replace()->into($index)__
 
 	Begins an `REPLACE`.
 
@@ -172,7 +172,7 @@ This will return an `INT` with the number of rows affected.
 
 This will return an `INT` with the number of rows affected.
 
-* __$sq = SphinxQL::create($conn)->update($index)__
+* __$sq = (new SphinxQL($conn))->update($index)__
 
 	Begins an `UPDATE`.
 
@@ -188,7 +188,7 @@ This will return an `INT` with the number of rows affected.
 
 Will return an array with an `INT` as first member, the number of rows deleted.
 
-* __$sq = SphinxQL::create($conn)->delete()->from($index)->where(...)__
+* __$sq = (new SphinxQL($conn))->delete()->from($index)->where(...)__
 
 	Begins a `DELETE`.
 
@@ -243,7 +243,8 @@ Will return an array with an `INT` as first member, the number of rows deleted.
     <?php
     try
     {
-        $result = SphinxQL::create($conn)->select()
+        $result = (new SphinxQL($conn))
+            ->select()
             ->from('rt')
             ->match('title', 'Sora no || Otoshimono', true)
             ->match('title', SphinxQL::expr('"Otoshimono"/3'))
@@ -296,15 +297,15 @@ Will return an array with an `INT` as first member, the number of rows deleted.
 
 #### TRANSACTION
 
-* __SphinxQL::create($conn)->transactionBegin()__
+* __(new SphinxQL($conn))->transactionBegin()__
 
 	Begins a transaction.
 
-* __SphinxQL::create($conn)->transactionCommit()__
+* __(new SphinxQL($conn))->transactionCommit()__
 
 	Commits a transaction.
 
-* __SphinxQL::create($conn)->transactionRollback()__
+* __(new SphinxQL($conn))->transactionRollback()__
 
 	Rollbacks a transaction.
 
@@ -342,11 +343,11 @@ Will return an array with an `INT` as first member, the number of rows deleted.
 
 ```php
 <?php
-$result = SphinxQL::create($this->conn)
+$result = (new SphinxQL($this->conn))
     ->select()
     ->from('rt')
     ->match('title', 'sora')
-    ->enqueue(SphinxQL::create($this->conn)->query('SHOW META')) // this returns the object with SHOW META query
+    ->enqueue((new SphinxQL($this->conn))->query('SHOW META')) // this returns the object with SHOW META query
     ->enqueue() // this returns a new object
     ->select()
     ->from('rt')
@@ -406,11 +407,11 @@ The following methods return a prepared `SphinxQL` object. You can also use `->e
 
 ```php
 <?php
-$result = SphinxQL::create($this->conn)
+$result = (new SphinxQL($this->conn))
     ->select()
     ->from('rt')
     ->where('gid', 9003)
-    ->enqueue(Helper::create($this->conn)->showMeta()) // this returns the object with SHOW META query prepared
+    ->enqueue((new Helper($this->conn))->showMeta()) // this returns the object with SHOW META query prepared
     ->enqueue() // this returns a new object
     ->select()
     ->from('rt')
@@ -418,19 +419,19 @@ $result = SphinxQL::create($this->conn)
     ->executeBatch();
 ```
 
-* `Helper::create($conn)->showMeta() => 'SHOW META'`
-* `Helper::create($conn)->showWarnings() => 'SHOW WARNINGS'`
-* `Helper::create($conn)->showStatus() => 'SHOW STATUS'`
-* `Helper::create($conn)->showTables() => 'SHOW TABLES'`
-* `Helper::create($conn)->showVariables() => 'SHOW VARIABLES'`
-* `Helper::create($conn)->setVariable($name, $value, $global = false)`
-* `Helper::create($conn)->callSnippets($data, $index, $query, $options = array())`
-* `Helper::create($conn)->callKeywords($text, $index, $hits = null)`
-* `Helper::create($conn)->describe($index)`
-* `Helper::create($conn)->createFunction($udf_name, $returns, $soname)`
-* `Helper::create($conn)->dropFunction($udf_name)`
-* `Helper::create($conn)->attachIndex($disk_index, $rt_index)`
-* `Helper::create($conn)->flushRtIndex($index)`
-* `Helper::create($conn)->optimizeIndex($index)`
-* `Helper::create($conn)->showIndexStatus($index)`
-* `Helper::create($conn)->flushRamchunk($index)`
+* `(new Helper($conn))->showMeta() => 'SHOW META'`
+* `(new Helper($conn))->showWarnings() => 'SHOW WARNINGS'`
+* `(new Helper($conn))->showStatus() => 'SHOW STATUS'`
+* `(new Helper($conn))->showTables() => 'SHOW TABLES'`
+* `(new Helper($conn))->showVariables() => 'SHOW VARIABLES'`
+* `(new Helper($conn))->setVariable($name, $value, $global = false)`
+* `(new Helper($conn))->callSnippets($data, $index, $query, $options = array())`
+* `(new Helper($conn))->callKeywords($text, $index, $hits = null)`
+* `(new Helper($conn))->describe($index)`
+* `(new Helper($conn))->createFunction($udf_name, $returns, $soname)`
+* `(new Helper($conn))->dropFunction($udf_name)`
+* `(new Helper($conn))->attachIndex($disk_index, $rt_index)`
+* `(new Helper($conn))->flushRtIndex($index)`
+* `(new Helper($conn))->optimizeIndex($index)`
+* `(new Helper($conn))->showIndexStatus($index)`
+* `(new Helper($conn))->flushRamchunk($index)`

--- a/src/Drivers/Mysqli/Connection.php
+++ b/src/Drivers/Mysqli/Connection.php
@@ -103,7 +103,7 @@ class Connection extends ConnectionBase
                 $this->getConnection()->error.' [ '.$query.']');
         }
 
-        return ResultSet::make($this, $resource);
+        return new ResultSet($this, $resource);
     }
 
     /**
@@ -131,7 +131,7 @@ class Connection extends ConnectionBase
                 $this->getConnection()->error.' [ '.implode(';', $queue).']');
         };
 
-        return MultiResultSet::make($this);
+        return new MultiResultSet($this);
     }
 
     /**

--- a/src/Drivers/Mysqli/MultiResultSet.php
+++ b/src/Drivers/Mysqli/MultiResultSet.php
@@ -13,22 +13,12 @@ class MultiResultSet extends MultiResultSetBase
     public $connection;
 
     /**
-     * @param MultiResultSetAdapter $adapter
      * @param Connection $connection
      */
-    public function __construct(MultiResultSetAdapter $adapter, Connection $connection)
+    public function __construct(Connection $connection)
     {
-        $this->adapter = $adapter;
+        $this->adapter = new MultiResultSetAdapter($connection);
         $this->connection = $connection;
     }
 
-    /**
-     * @param Connection $connection
-     * @return MultiResultSet
-     */
-    public static function make(Connection $connection)
-    {
-        $adapter = new MultiResultSetAdapter($connection);
-        return new MultiResultSet($adapter, $connection);
-    }
 }

--- a/src/Drivers/Mysqli/MultiResultSetAdapter.php
+++ b/src/Drivers/Mysqli/MultiResultSetAdapter.php
@@ -40,7 +40,7 @@ class MultiResultSetAdapter implements \Foolz\SphinxQL\Drivers\MultiResultSetAda
      */
     public function current()
     {
-        return ResultSet::make($this->connection, $this->connection->getConnection()->store_result());
+        return new ResultSet($this->connection, $this->connection->getConnection()->store_result());
     }
 
     /**

--- a/src/Drivers/Mysqli/ResultSet.php
+++ b/src/Drivers/Mysqli/ResultSet.php
@@ -18,27 +18,15 @@ class ResultSet extends ResultSetBase
     protected $result;
 
     /**
-     * @param ResultSetAdapter $adapter
      * @param Connection $connection
      * @param null|\mysqli_result $result
      */
-    public function __construct(ResultSetAdapter $adapter, Connection $connection, $result = null)
+    public function __construct(Connection $connection, $result = null)
     {
         $this->connection = $connection;
-        $this->adapter = $adapter;
+        $this->adapter = new ResultSetAdapter($connection, $result);
         $this->result = $result;
         $this->init();
-    }
-
-    /**
-     * @param Connection $connection
-     * @param null|\mysqli_result $result
-     * @return ResultSet
-     */
-    public static function make(Connection $connection, $result = null)
-    {
-        $adapter = new ResultSetAdapter($connection, $result);
-        return new ResultSet($adapter, $connection, $result);
     }
 
     /**

--- a/src/Drivers/Pdo/Connection.php
+++ b/src/Drivers/Pdo/Connection.php
@@ -34,7 +34,7 @@ class Connection extends ConnectionBase
             throw new DatabaseException($exception->getMessage() . ' [' . $query . ']');
         }
 
-        return ResultSet::make($stm);
+        return new ResultSet($stm);
     }
 
     /**
@@ -102,7 +102,7 @@ class Connection extends ConnectionBase
             throw new DatabaseException($exception->getMessage() .' [ '.implode(';', $queue).']');
         }
 
-        return MultiResultSet::make($statement);
+        return new MultiResultSet($statement);
     }
 
     /**

--- a/src/Drivers/Pdo/MultiResultSet.php
+++ b/src/Drivers/Pdo/MultiResultSet.php
@@ -14,22 +14,12 @@ class MultiResultSet extends MultiResultSetBase
     public $statement;
 
     /**
-     * @param MultiResultSetAdapter $adapter
      * @param PDOStatement $statement
      */
-    public function __construct(MultiResultSetAdapter $adapter, PDOStatement $statement)
+    public function __construct(PDOStatement $statement)
     {
-        $this->adapter = $adapter;
+        $this->adapter = new MultiResultSetAdapter($statement);
         $this->statement = $statement;
     }
 
-    /**
-     * @param PDOStatement $statement
-     * @return MultiResultSet
-     */
-    public static function make(PDOStatement $statement)
-    {
-        $adapter = new MultiResultSetAdapter($statement);
-        return new MultiResultSet($adapter, $statement);
-    }
 }

--- a/src/Drivers/Pdo/MultiResultSetAdapter.php
+++ b/src/Drivers/Pdo/MultiResultSetAdapter.php
@@ -34,7 +34,7 @@ class MultiResultSetAdapter implements \Foolz\SphinxQL\Drivers\MultiResultSetAda
      */
     public function current()
     {
-        return ResultSet::make($this->statement);
+        return new ResultSet($this->statement);
     }
 
     /**

--- a/src/Drivers/Pdo/ResultSet.php
+++ b/src/Drivers/Pdo/ResultSet.php
@@ -11,25 +11,14 @@ class ResultSet extends ResultSetBase
     protected $statement;
 
     /**
-     * @param ResultSetAdapter $adapter
      * @param PDOStatement $statement
      */
-    public function __construct(ResultSetAdapter $adapter, PDOStatement $statement)
+    public function __construct(PDOStatement $statement)
     {
         $this->statement = $statement;
-        $this->adapter = $adapter;
+        $this->adapter = new ResultSetAdapter($statement);
         $this->init();
         $this->store();
-    }
-
-    /**
-     * @param PDOStatement $statement
-     * @return ResultSet
-     */
-    public static function make(PDOStatement $statement)
-    {
-        $adapter = new ResultSetAdapter($statement);
-        return new ResultSet($adapter, $statement);
     }
 
     /**

--- a/src/Facet.php
+++ b/src/Facet.php
@@ -63,24 +63,10 @@ class Facet
 
     /**
      * @param ConnectionInterface|null $connection
-     * @param bool                     $static
      */
-    public function __construct(ConnectionInterface $connection = null, $static = false)
+    public function __construct(ConnectionInterface $connection = null)
     {
         $this->connection = $connection;
-    }
-
-    /**
-     * Creates and setups a Facet object
-     * The connection is required only in case this is not to be passed to a SphinxQL object via $sq->facet()
-     *
-     * @param ConnectionInterface|null $connection
-     *
-     * @return static
-     */
-    public static function create(ConnectionInterface $connection = null)
-    {
-        return new static($connection);
     }
 
     /**

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -24,23 +24,13 @@ class Helper
     }
 
     /**
-     * @param ConnectionInterface $connection
-     *
-     * @return static
-     */
-    public static function create(ConnectionInterface $connection)
-    {
-        return new static($connection);
-    }
-
-    /**
      * Returns a new SphinxQL instance
      *
      * @return SphinxQL
      */
     protected function getSphinxQL()
     {
-        return SphinxQL::create($this->connection);
+        return new SphinxQL($this->connection);
     }
 
     /**
@@ -61,6 +51,7 @@ class Helper
      * @param array $result The result of an executed query
      *
      * @return array Associative array with Variable_name as key and Value as value
+     * @todo make non static
      */
     public static function pairsToAssoc($result)
     {

--- a/src/Match.php
+++ b/src/Match.php
@@ -38,16 +38,6 @@ class Match
     }
 
     /**
-     * @param SphinxQL $sphinxql
-     *
-     * @return static
-     */
-    public static function create(SphinxQL $sphinxql)
-    {
-        return new static($sphinxql);
-    }
-
-    /**
      * Match text or sub expression.
      *
      * Examples:

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -216,23 +216,10 @@ class SphinxQL
 
     /**
      * @param ConnectionInterface|null $connection
-     * @param bool                     $static
      */
-    public function __construct(ConnectionInterface $connection = null, $static = false)
+    public function __construct(ConnectionInterface $connection = null)
     {
         $this->connection = $connection;
-    }
-
-    /**
-     * Creates and setups a SphinxQL object
-     *
-     * @param ConnectionInterface $connection
-     *
-     * @return static
-     */
-    public static function create(ConnectionInterface $connection)
-    {
-        return new static($connection);
     }
 
     /**
@@ -255,6 +242,7 @@ class SphinxQL
      * @param string $string The string to keep unaltered
      *
      * @return Expression The new Expression
+     * @todo make non static
      */
     public static function expr($string = '')
     {

--- a/tests/SphinxQL/FacetTest.php
+++ b/tests/SphinxQL/FacetTest.php
@@ -37,33 +37,41 @@ class FacetTest  extends \PHPUnit\Framework\TestCase
         self::$conn = $conn;
     }
 
+    /**
+     * @return Facet
+     */
+    protected function createFacet()
+    {
+        return new Facet(self::$conn);
+    }
+
     public function testFacet()
     {
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid'))
             ->getFacet();
 
         $this->assertEquals('FACET gid', $facet);
 
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'title', 'content'))
             ->getFacet();
 
         $this->assertEquals('FACET gid, title, content', $facet);
 
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet('gid', 'title', 'content')
             ->getFacet();
 
         $this->assertEquals('FACET gid, title, content', $facet);
 
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('aliAS' => 'gid'))
             ->getFacet();
 
         $this->assertEquals('FACET gid AS aliAS', $facet);
 
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'name' => 'title', 'content'))
             ->getFacet();
 
@@ -80,13 +88,13 @@ class FacetTest  extends \PHPUnit\Framework\TestCase
 
     public function testFacetFunction()
     {
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facetFunction('INTERVAL', array('price', 200, 400, 600, 800))
             ->getFacet();
 
         $this->assertEquals('FACET INTERVAL(price,200,400,600,800)', $facet);
 
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facetFunction('COUNT', 'gid')
             ->getFacet();
 
@@ -95,7 +103,7 @@ class FacetTest  extends \PHPUnit\Framework\TestCase
 
     public function testBy()
     {
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'title', 'content'))
             ->by('gid')
             ->getFacet();
@@ -105,14 +113,14 @@ class FacetTest  extends \PHPUnit\Framework\TestCase
 
     public function testOrderBy()
     {
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'title'))
             ->orderBy('gid', 'DESC')
             ->getFacet();
 
         $this->assertEquals('FACET gid, title ORDER BY gid DESC', $facet);
 
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'content'))
             ->orderBy('gid', 'ASC')
             ->orderBy('content', 'DESC')
@@ -123,7 +131,7 @@ class FacetTest  extends \PHPUnit\Framework\TestCase
 
     public function testOrderByFunction()
     {
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'title'))
             ->orderByFunction('COUNT','*', 'DESC')
             ->getFacet();
@@ -133,7 +141,7 @@ class FacetTest  extends \PHPUnit\Framework\TestCase
 
     public function testLimit()
     {
-        $facet = Facet::create(self::$conn)
+        $facet = $this->createFacet()
             ->facet(array('gid', 'title'))
             ->orderByFunction('COUNT', '*', 'DESC')
             ->limit(5, 5)

--- a/tests/SphinxQL/MultiResultSetTest.php
+++ b/tests/SphinxQL/MultiResultSetTest.php
@@ -36,14 +36,23 @@ class MultiResultSetTest extends \PHPUnit\Framework\TestCase
         $conn->setParam('port', 9307);
         self::$conn = $conn;
 
-        SphinxQL::create(self::$conn)->getConnection()->query('TRUNCATE RTINDEX rt');
+        (new SphinxQL(self::$conn))->getConnection()->query('TRUNCATE RTINDEX rt');
+    }
+
+    /**
+     * @return SphinxQL
+     */
+    protected function createSphinxQL()
+    {
+        return new SphinxQL(self::$conn);
     }
 
     public function refill()
     {
-        SphinxQL::create(self::$conn)->getConnection()->query('TRUNCATE RTINDEX rt');
+        $this->createSphinxQL()->getConnection()->query('TRUNCATE RTINDEX rt');
 
-        $sq = SphinxQL::create(self::$conn)->insert()
+        $sq = $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->columns('id', 'gid', 'title', 'content');
 

--- a/tests/SphinxQL/ResultSetTest.php
+++ b/tests/SphinxQL/ResultSetTest.php
@@ -36,14 +36,23 @@ class ResultSetTest extends \PHPUnit\Framework\TestCase
         $conn->setParam('port', 9307);
         self::$conn = $conn;
 
-        SphinxQL::create(self::$conn)->getConnection()->query('TRUNCATE RTINDEX rt');
+        (new SphinxQL(self::$conn))->getConnection()->query('TRUNCATE RTINDEX rt');
+    }
+
+    /**
+     * @return SphinxQL
+     */
+    protected function createSphinxQL()
+    {
+        return new SphinxQL(self::$conn);
     }
 
     public function refill()
     {
-        SphinxQL::create(self::$conn)->getConnection()->query('TRUNCATE RTINDEX rt');
+        $this->createSphinxQL()->getConnection()->query('TRUNCATE RTINDEX rt');
 
-        $sq = SphinxQL::create(self::$conn)->insert()
+        $sq = $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->columns('id', 'gid', 'title', 'content');
 

--- a/tests/SphinxQL/SphinxQLTest.php
+++ b/tests/SphinxQL/SphinxQLTest.php
@@ -35,13 +35,23 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $conn->setParam('port', 9307);
         self::$conn = $conn;
 
-        SphinxQL::create(self::$conn)->getConnection()->query('TRUNCATE RTINDEX rt');
+        (new SphinxQL(self::$conn))->getConnection()->query('TRUNCATE RTINDEX rt');
     }
 
-    public function refill() {
-        SphinxQL::create(self::$conn)->getConnection()->query('TRUNCATE RTINDEX rt');
+    /**
+     * @return SphinxQL
+     */
+    protected function createSphinxQL()
+    {
+        return new SphinxQL(self::$conn);
+    }
 
-        $sq = SphinxQL::create(self::$conn)->insert()
+    public function refill()
+    {
+        $this->createSphinxQL()->getConnection()->query('TRUNCATE RTINDEX rt');
+
+        $sq = $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->columns('id', 'gid', 'title', 'content');
 
@@ -72,15 +82,15 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testTransactions()
     {
-        SphinxQL::create(self::$conn)->transactionBegin();
-        SphinxQL::create(self::$conn)->transactionRollback();
-        SphinxQL::create(self::$conn)->transactionBegin();
-        SphinxQL::create(self::$conn)->transactionCommit();
+        $this->createSphinxQL()->transactionBegin();
+        $this->createSphinxQL()->transactionRollback();
+        $this->createSphinxQL()->transactionBegin();
+        $this->createSphinxQL()->transactionCommit();
     }
 
     public function testQuery()
     {
-        $describe = SphinxQL::create(self::$conn)
+        $describe = $this->createSphinxQL()
             ->query('DESCRIBE rt')
             ->execute()
             ->getStored();
@@ -96,7 +106,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             $describe
         );
 
-        $describe = SphinxQL::create(self::$conn)
+        $describe = $this->createSphinxQL()
             ->query('DESCRIBE rt');
         $describe->execute();
         $describe = $describe
@@ -128,7 +138,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testInsert()
     {
-        SphinxQL::create(self::$conn)->insert()
+        $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->set(array(
                 'id' => 10,
@@ -138,27 +149,31 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             ))
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->execute()
             ->getStored();
 
         $this->assertCount(1, $result);
 
-        SphinxQL::create(self::$conn)->insert()
+        $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->columns('id', 'title', 'content', 'gid')
             ->values(11, 'this is a title', 'this is the content', 100)
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->execute()
             ->getStored();
 
         $this->assertCount(2, $result);
 
-        SphinxQL::create(self::$conn)->insert()
+        $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->value('id', 12)
             ->value('title', 'simple logic')
@@ -166,14 +181,16 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             ->value('gid', 200)
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->execute()
             ->getStored();
 
         $this->assertCount(3, $result);
 
-        SphinxQL::create(self::$conn)->insert()
+        $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->columns(array('id', 'title', 'content', 'gid'))
             ->values(array(13, 'i am getting bored', 'with all this CONTENT', 300))
@@ -181,28 +198,32 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             ->values(15, 'there\'s no hope in this class', 'just give up', 300)
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->execute()
             ->getStored();
 
         $this->assertCount(6, $result);
 
-        SphinxQL::create(self::$conn)->insert()
+        $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->columns('id', 'title', 'content', 'gid')
             ->values(16, 'we need to test', 'selecting the best result in groups', 500)
             ->values(17, 'what is there to do', 'we need to create dummy data for tests', 500)
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->execute()
             ->getStored();
 
         $this->assertCount(8, $result);
 
-        SphinxQL::create(self::$conn)->insert()
+        $this->createSphinxQL()
+            ->insert()
             ->into('rt')
             ->set(array(
                 'id' => 18,
@@ -218,7 +239,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             ))
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->execute()
             ->getStored();
@@ -240,7 +262,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testReplace()
     {
-        $result = SphinxQL::create(self::$conn)->replace()
+        $result = $this->createSphinxQL()
+            ->replace()
             ->into('rt')
             ->set(array(
                 'id' => 10,
@@ -253,7 +276,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', '=', 10)
             ->execute()
@@ -261,7 +285,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('9002', $result[0]['gid']);
 
-        $result = SphinxQL::create(self::$conn)->replace()
+        $result = $this->createSphinxQL()
+            ->replace()
             ->into('rt')
             ->columns('id', 'title', 'content', 'gid')
             ->values(10, 'modifying the same line again', 'because i am that lazy', 9003)
@@ -271,7 +296,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(2, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', 'IN', array(10, 11))
             ->execute()
@@ -280,7 +306,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('9003', $result[0]['gid']);
         $this->assertEquals('300', $result[1]['gid']);
 
-        SphinxQL::create(self::$conn)->replace()
+        $this->createSphinxQL()
+            ->replace()
             ->into('rt')
             ->value('id', 11)
             ->value('title', 'replacing value by value')
@@ -288,7 +315,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             ->value('gid', 200)
             ->execute();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', '=', 11)
             ->execute()
@@ -306,7 +334,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testUpdate()
     {
-        $result = SphinxQL::create(self::$conn)->update('rt')
+        $result = $this->createSphinxQL()
+            ->update('rt')
             ->where('id', '=', 11)
             ->value('gid', 201)
             ->execute()
@@ -314,7 +343,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->update('rt')
+        $result = $this->createSphinxQL()
+            ->update('rt')
             ->where('gid', '=', 300)
             ->value('gid', 305)
             ->execute()
@@ -322,7 +352,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(3, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', '=', 11)
             ->execute()
@@ -330,13 +361,15 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('201', $result[0]['gid']);
 
-        $result = SphinxQL::create(self::$conn)->update('rt')
+        $result = $this->createSphinxQL()
+            ->update('rt')
             ->where('gid', '=', 305)
             ->set(array('gid' => 304))
             ->execute()
             ->getStored();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', '=', 304)
             ->execute()
@@ -345,21 +378,24 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(3, $result);
 
         self::$conn->query('ALTER TABLE rt ADD COLUMN tags MULTI');
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('tags', 222)
             ->execute()
             ->getStored();
         $this->assertEmpty($result);
 
-        $result = SphinxQL::create(self::$conn)->update('rt')
+        $result = $this->createSphinxQL()
+            ->update('rt')
             ->where('id', '=', 15)
             ->value('tags', array(111, 222))
             ->execute()
             ->getStored();
         $this->assertSame(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('tags', 222)
             ->execute()
@@ -386,7 +422,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', 'BETWEEN', array(300, 400))
             ->execute()
@@ -394,7 +431,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(3, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', 'IN', array(11, 12, 13))
             ->execute()
@@ -402,7 +440,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(3, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', 'NOT IN', array(11, 12))
             ->execute()
@@ -410,7 +449,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(6, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', '>', 300)
             ->execute()
@@ -418,13 +458,15 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(6, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', 304)
             ->execute()
             ->getStored();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', '>', 300)
             ->execute()
@@ -432,7 +474,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(6, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', '>', 300)
             ->where('id', '!=', 15)
@@ -441,7 +484,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(5, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('content', 'content')
             ->where('gid', '>', 200)
@@ -460,7 +504,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('content', 'content')
             ->execute()
@@ -468,7 +513,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(2, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('title', 'value')
             ->execute()
@@ -476,7 +522,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('title', 'value')
             ->match('content', 'directly')
@@ -485,7 +532,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('*', 'directly')
             ->execute()
@@ -493,7 +541,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match(array('title', 'content'), 'to')
             ->execute()
@@ -501,7 +550,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(3, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('content', 'directly | lazy', true)
             ->execute()
@@ -509,7 +559,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(2, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match(function ($m) {
                 $m->field('content')
@@ -521,11 +572,12 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(2, $result);
 
-        $match = Match::create(SphinxQL::create(self::$conn))
+        $match = (new Match($this->createSphinxQL()))
             ->field('content')
             ->match('directly')
             ->orMatch('lazy');
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match($match)
             ->execute()
@@ -533,7 +585,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(2, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('')
             ->compile()
@@ -545,19 +598,19 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     public function testEscapeMatch()
     {
         $match = 'this MAYBE that^32 and | hi';
-        $this->assertSame('this maybe that\^32 and \| hi', SphinxQL::create(self::$conn)->escapeMatch($match));
-        $this->assertSame($match, SphinxQL::create(self::$conn)->escapeMatch(SphinxQL::expr($match)));
-        $this->assertSame('stärkergradig \| mb', SphinxQL::create(self::$conn)->escapeMatch('stärkergradig | mb'));
+        $this->assertSame('this maybe that\^32 and \| hi', $this->createSphinxQL()->escapeMatch($match));
+        $this->assertSame($match, $this->createSphinxQL()->escapeMatch(SphinxQL::expr($match)));
+        $this->assertSame('stärkergradig \| mb', $this->createSphinxQL()->escapeMatch('stärkergradig | mb'));
     }
 
     public function testHalfEscapeMatch()
     {
         $match = 'this MAYBE that^32 and | hi';
-        $this->assertSame('this maybe that\^32 and | hi', SphinxQL::create(self::$conn)->halfEscapeMatch($match));
-        $this->assertSame($match, SphinxQL::create(self::$conn)->halfEscapeMatch(SphinxQL::expr($match)));
-        $this->assertSame('this \- not -that | hi \-', SphinxQL::create(self::$conn)->halfEscapeMatch('this -- not -that | | hi -'));
-        $this->assertSame('stärkergradig | mb', SphinxQL::create(self::$conn)->halfEscapeMatch('stärkergradig | mb'));
-        $this->assertSame('"unmatched quotes"', SphinxQL::create(self::$conn)->halfEscapeMatch('"unmatched quotes'));
+        $this->assertSame('this maybe that\^32 and | hi', $this->createSphinxQL()->halfEscapeMatch($match));
+        $this->assertSame($match, $this->createSphinxQL()->halfEscapeMatch(SphinxQL::expr($match)));
+        $this->assertSame('this \- not -that | hi \-', $this->createSphinxQL()->halfEscapeMatch('this -- not -that | | hi -'));
+        $this->assertSame('stärkergradig | mb', $this->createSphinxQL()->halfEscapeMatch('stärkergradig | mb'));
+        $this->assertSame('"unmatched quotes"', $this->createSphinxQL()->halfEscapeMatch('"unmatched quotes'));
     }
 
     /**
@@ -567,11 +620,11 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     */
     public function testEscapeChars()
     {
-        $this->assertEquals(array('%' => '\%'), SphinxQL::create(self::$conn)->compileEscapeChars(array('%')));
-        $this->assertEquals(array('@' => '\@'), SphinxQL::create(self::$conn)->compileEscapeChars(array('@')));
+        $this->assertEquals(array('%' => '\%'), $this->createSphinxQL()->compileEscapeChars(array('%')));
+        $this->assertEquals(array('@' => '\@'), $this->createSphinxQL()->compileEscapeChars(array('@')));
 
         $match = 'this MAYBE that^32 and | hi';
-        $sphinxql = SphinxQL::create(self::$conn)->setFullEscapeChars(array('^'));
+        $sphinxql = $this->createSphinxQL()->setFullEscapeChars(array('^'));
         $this->assertSame('this maybe that\^32 and | hi', $sphinxql->escapeMatch($match));
 
         $sphinxql->setHalfEscapeChars(array('|'));
@@ -582,7 +635,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('content', 'content')
             ->option('max_matches', 1)
@@ -591,7 +645,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->match('content', 'content')
             ->option('max_matches', SphinxQL::expr('1'))
@@ -600,7 +655,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->option('comment', 'this should be quoted')
             ->compile()
@@ -608,7 +664,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('SELECT * FROM rt OPTION comment = \'this should be quoted\'', $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->option('field_weights', SphinxQL::expr('(content=50)'))
             ->compile()
@@ -616,7 +673,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('SELECT * FROM rt OPTION field_weights = (content=50)', $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->option('field_weights', array(
                 'title'   => 80,
@@ -633,7 +691,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select(SphinxQL::expr('count(*)'))
+        $result = $this->createSphinxQL()
+            ->select(SphinxQL::expr('count(*)'))
             ->from('rt')
             ->groupBy('gid')
             ->execute()
@@ -647,7 +706,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select(SphinxQL::expr('count(*) as cnt'))
+        $result = $this->createSphinxQL()
+            ->select(SphinxQL::expr('count(*) as cnt'))
             ->from('rt')
             ->groupBy('gid')
             ->having('cnt', '>', 1)
@@ -656,7 +716,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(2, $result);
         $this->assertEquals('2', $result[1]['cnt']);
 
-        $result = SphinxQL::create(self::$conn)->select(SphinxQL::expr('count(*) as cnt'), SphinxQL::expr('GROUPBY() gd'))
+        $result = $this->createSphinxQL()
+            ->select(SphinxQL::expr('count(*) as cnt'), SphinxQL::expr('GROUPBY() gd'))
             ->from('rt')
             ->groupBy('gid')
             ->having('gd', 304)
@@ -669,7 +730,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->orderBy('id', 'desc')
             ->execute()
@@ -677,7 +739,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('17', $result[0]['id']);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->orderBy('id', 'asc')
             ->execute()
@@ -690,7 +753,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', 500)
             ->groupBy('gid')
@@ -700,7 +764,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('17', $result[0]['id']);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('gid', 500)
             ->groupBy('gid')
@@ -713,7 +778,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
     public function testGroupNBy()
     {
-        $query = SphinxQL::create(self::$conn)->select()
+        $query = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->groupBy('gid');
         $this->assertEquals(
@@ -751,7 +817,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->offset(4)
             ->execute()
@@ -764,7 +831,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->limit(3)
             ->execute()
@@ -772,7 +840,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(3, $result);
 
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->limit(2, 3)
             ->execute()
@@ -790,7 +859,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)->delete()
+        $result = $this->createSphinxQL()
+            ->delete()
             ->from('rt')
             ->where('id', 'IN', array(10, 11, 12))
             ->execute()
@@ -810,11 +880,11 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
 
-        $result = SphinxQL::create(self::$conn)
+        $result = $this->createSphinxQL()
             ->select()
             ->from('rt')
             ->where('gid', 9003)
-            ->enqueue(Helper::create(self::$conn)->showMeta())
+            ->enqueue((new Helper(self::$conn))->showMeta())
             ->enqueue()
             ->select()
             ->from('rt')
@@ -833,7 +903,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyQueue()
     {
-        SphinxQL::create(self::$conn)
+        $this->createSphinxQL()
             ->executeBatch()
             ->getStored();
     }
@@ -849,7 +919,8 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testResetMethods()
     {
-        $result = SphinxQL::create(self::$conn)->select()
+        $result = $this->createSphinxQL()
+            ->select()
             ->from('rt')
             ->where('id', 'IN', array(10, 11))
             ->resetWhere()
@@ -877,7 +948,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     public function testSelect()
     {
         $this->refill();
-        $result = SphinxQL::create(self::$conn)
+        $result = $this->createSphinxQL()
             ->select(array('id', 'gid'))
             ->from('rt')
             ->execute()
@@ -887,7 +958,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('10', $result[0]['id']);
         $this->assertEquals('9003', $result[0]['gid']);
 
-        $result = SphinxQL::create(self::$conn)
+        $result = $this->createSphinxQL()
             ->select('id', 'gid')
             ->from('rt')
             ->execute()
@@ -897,7 +968,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('10', $result[0]['id']);
         $this->assertEquals('9003', $result[0]['gid']);
 
-        $result = SphinxQL::create(self::$conn)
+        $result = $this->createSphinxQL()
             ->select(array('id'))
             ->from('rt')
             ->execute()
@@ -906,7 +977,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayNotHasKey('gid', $result[0]);
         $this->assertEquals('10', $result[0]['id']);
 
-        $result = SphinxQL::create(self::$conn)
+        $result = $this->createSphinxQL()
             ->select('id')
             ->from('rt')
             ->execute()
@@ -919,7 +990,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     public function testSubselect()
     {
         $this->refill();
-        $query = SphinxQL::create(self::$conn)
+        $query = $this->createSphinxQL()
             ->select()
             ->from(function ($q) {
                 $q->select('id')
@@ -938,11 +1009,11 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayNotHasKey('gid', $result[0]);
         $this->assertEquals('10', $result[0]['id']);
 
-        $subquery = SphinxQL::create(self::$conn)
+        $subquery = $this->createSphinxQL()
             ->select('id')
             ->from('rt')
             ->orderBy('id', 'DESC');
-        $query = SphinxQL::create(self::$conn)
+        $query = $this->createSphinxQL()
             ->select()
             ->from($subquery)
             ->orderBy('id', 'ASC');
@@ -974,7 +1045,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     public function testSetSelect()
     {
         $this->refill();
-        $q1 = SphinxQL::create(self::$conn)
+        $q1 = $this->createSphinxQL()
             ->select(array('id', 'gid'))
             ->from('rt');
         $q2 = clone $q1;
@@ -990,7 +1061,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('id', $result[0]);
         $this->assertArrayNotHasKey('gid', $result[0]);
 
-        $q1 = SphinxQL::create(self::$conn)
+        $q1 = $this->createSphinxQL()
             ->select('id', 'gid')
             ->from('rt');
         $q2 = clone $q1;
@@ -1012,7 +1083,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetSelect()
     {
-        $query = SphinxQL::create(self::$conn)
+        $query = $this->createSphinxQL()
             ->select('id', 'gid')
             ->from('rt');
         $this->assertEquals(array('id', 'gid'), $query->getSelect());
@@ -1028,10 +1099,10 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
 
         // test both setting and not setting the connection
         foreach (array(self::$conn, null) as $conn) {
-            $result = SphinxQL::create(self::$conn)
+            $result = $this->createSphinxQL()
                 ->select()
                 ->from('rt')
-                ->facet(Facet::create($conn)
+                ->facet((new Facet($conn))
                     ->facetFunction('INTERVAL', array('gid', 300, 600))
                     ->orderByFunction('FACET', '', 'ASC'))
                 ->executeBatch()
@@ -1045,10 +1116,10 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals('5', $result[1][1]['count(*)']);
             $this->assertEquals('1', $result[1][2]['count(*)']);
 
-            $result = SphinxQL::create(self::$conn)
+            $result = $this->createSphinxQL()
                 ->select()
                 ->from('rt')
-                ->facet(Facet::create($conn)
+                ->facet((new Facet($conn))
                     ->facet(array('gid'))
                     ->orderBy('gid', 'ASC'))
                 ->executeBatch()
@@ -1068,7 +1139,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
     // issue #82
     public function testClosureMisuse()
     {
-        $query = SphinxQL::create(self::$conn)
+        $query = $this->createSphinxQL()
             ->select()
             ->from('strlen')
             ->orderBy('id', 'ASC');
@@ -1077,7 +1148,7 @@ class SphinxQLTest extends \PHPUnit\Framework\TestCase
             $query->compile()->getCompiled()
         );
 
-        $query = SphinxQL::create(self::$conn)
+        $query = $this->createSphinxQL()
             ->select()
             ->from('rt')
             ->match('strlen', 'value');


### PR DESCRIPTION
dropped static creational methods like create() and make()
expr() and pairsToAssoc() left (marked by todo)
Now there is no dependency between static method and constructor, so there is no need to support both of them.