### PR TITLE
drop getCount() from ResultSetInterface

### DIFF
--- a/src/Drivers/ResultSetBase.php
+++ b/src/Drivers/ResultSetBase.php
@@ -79,16 +79,6 @@ abstract class ResultSetBase implements ResultSetInterface
     }
 
     /**
-     * Returns the number of rows in the result set
-     *
-     * @return int The number of rows in the result set
-     */
-    public function getCount()
-    {
-        return $this->num_rows;
-    }
-
-    /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Whether a offset exists
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
@@ -223,17 +213,12 @@ abstract class ResultSetBase implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * Count elements of an object
-     * @link http://php.net/manual/en/countable.count.php
-     * @return int The custom count as an integer.
-     * </p>
-     * <p>
-     * The return value is cast to an integer.
+     * Returns the number of rows in the result set
+     * @inheritdoc
      */
     public function count()
     {
-        return $this->getCount();
+        return $this->num_rows;
     }
 
     protected function init()

--- a/src/Drivers/ResultSetInterface.php
+++ b/src/Drivers/ResultSetInterface.php
@@ -49,13 +49,6 @@ interface ResultSetInterface extends \ArrayAccess, \Iterator, \Countable
     public function getAffectedRows();
 
     /**
-     * Returns the number of rows in the result set
-     *
-     * @return int The number of rows in the result set
-     */
-    public function getCount();
-
-    /**
      * Fetches all the rows as an array of associative arrays
      *
      * @return array An array of associative arrays

--- a/tests/SphinxQL/ResultSetTest.php
+++ b/tests/SphinxQL/ResultSetTest.php
@@ -145,11 +145,11 @@ class ResultSetTest extends \PHPUnit\Framework\TestCase
         $res->toNextRow()->toNextRow();
     }
 
-    public function testGetCount()
+    public function testCount()
     {
         $this->refill();
         $res = self::$conn->query('SELECT * FROM rt');
-        $this->assertEquals(8, $res->getCount());
+        $this->assertEquals(8, $res->count());
     }
 
     public function testFetchAllAssoc()
@@ -302,8 +302,7 @@ class ResultSetTest extends \PHPUnit\Framework\TestCase
     {
         $this->refill();
         $res = self::$conn->query('SELECT * FROM rt');
-        $this->assertEquals($res->getCount(), $res->count());
-        $this->assertEquals($res->getCount(), count($res));
+        $this->assertEquals($res->count(), count($res));
     }
 
     public function testIterator()


### PR DESCRIPTION
dropped getCount() from ResultSetInterface because Countable interface is implemented and there is already count() method 
there is no need in method which do the same as count() should