### PR TITLE
make public properties protected

### DIFF
--- a/src/Drivers/MultiResultSetBase.php
+++ b/src/Drivers/MultiResultSetBase.php
@@ -8,12 +8,12 @@ abstract class MultiResultSetBase implements MultiResultSetInterface
     /**
      * @var null|array
      */
-    public $stored;
+    protected $stored;
 
     /**
      * @var int
      */
-    public $cursor = 0;
+    protected $cursor = 0;
 
     /**
      * @var int

--- a/src/Drivers/Mysqli/MultiResultSet.php
+++ b/src/Drivers/Mysqli/MultiResultSet.php
@@ -10,7 +10,7 @@ class MultiResultSet extends MultiResultSetBase
     /**
      * @var Connection
      */
-    public $connection;
+    protected $connection;
 
     /**
      * @param Connection $connection

--- a/src/Drivers/Pdo/MultiResultSet.php
+++ b/src/Drivers/Pdo/MultiResultSet.php
@@ -11,7 +11,7 @@ class MultiResultSet extends MultiResultSetBase
     /**
      * @var PDOStatement
      */
-    public $statement;
+    protected $statement;
 
     /**
      * @param PDOStatement $statement


### PR DESCRIPTION
This is very bad to have public properties
Well, I did them protected )

And is there any reason to store unused $connection and $statement in Pdo and Mysqli MultiResultSet ?
May be we should remove them ?