### PR TITLE
Manticore build fixes

### DIFF
--- a/tests/install.sh
+++ b/tests/install.sh
@@ -12,8 +12,8 @@ case $SEARCH_BUILD in
     wget --quiet http://sphinxsearch.com/files/sphinx-3.0.3-facc3fb-linux-amd64.tar.gz
     tar zxvf sphinx-3.0.3-facc3fb-linux-amd64.tar.gz
     ;;
-  MANITCORE)
+  MANTICORE)
     wget --quiet -O search.deb https://github.com/manticoresoftware/manticoresearch/releases/download/2.6.3/manticore_2.6.3-180328-cccb538-release-stemmer.trusty_amd64-bin.deb
-    dpkg -i search.deb
+    dpkg -x search.deb .
     ;;
 esac

--- a/tests/ms_test_udf.c
+++ b/tests/ms_test_udf.c
@@ -1,0 +1,15 @@
+//------------- see sphinxudf.h -------------//
+#define SPH_UDF_VERSION 9
+typedef struct st_sphinx_udf_args SPH_UDF_ARGS;
+typedef struct st_sphinx_udf_init SPH_UDF_INIT;
+//-------------------------------------------//
+
+int test_udf_ver()
+{
+    return SPH_UDF_VERSION;
+}
+
+int my_udf(SPH_UDF_INIT* init, SPH_UDF_ARGS* args, char* error_flag)
+{
+    return 42;
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,6 +13,7 @@ case $SEARCH_BUILD in
     ;;
   MANTICORE)
     WORK=$HOME/search
+    gcc -shared -o data/test_udf.so ms_test_udf.c
     $WORK/usr/bin/searchd -c sphinx.conf
     ;;
 esac


### PR DESCRIPTION
In regard to #141:
For Manticore, a separate test_udf.c is needed as the SPH_UDF_VERSION was increased from 8 to 9. Also fixed some issues in the bash scripts.
