### PR TITLE
Percolate class for Manticore PQ feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,9 @@ before_script:
   - cd tests
   - $TRAVIS_BUILD_DIR/tests/run.sh
 
-script: phpunit --configuration travis/$DRIVER.phpunit.xml --coverage-text
+script:
+  - if [ $SEARCH_BUILD == "MANTICORE" ]; then
+       phpunit --configuration travis/$DRIVER.phpunit.xml --coverage-text
+    else
+       phpunit --configuration travis/$DRIVER.phpunit.xml --exclude-group=Manticore --coverage-text
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ php:
   - 7.1
 
 env:
-  - DRIVER=mysqli SEARCH_BUILD=SPHINX2 EXCLUDE_GROUP="--exclude-group=Manitcore"
-  - DRIVER=mysqli SEARCH_BUILD=SPHINX3 EXCLUDE_GROUP="--exclude-group=Manitcore"
+  - DRIVER=mysqli SEARCH_BUILD=SPHINX2 EXCLUDE_GROUP="--exclude-group=Manticore"
+  - DRIVER=mysqli SEARCH_BUILD=SPHINX3 EXCLUDE_GROUP="--exclude-group=Manticore"
   - DRIVER=mysqli SEARCH_BUILD=MANTICORE
-  - DRIVER=pdo SEARCH_BUILD=SPHINX2 EXCLUDE_GROUP="--exclude-group=Manitcore"
-  - DRIVER=pdo SEARCH_BUILD=SPHINX3 EXCLUDE_GROUP="--exclude-group=Manitcore"
+  - DRIVER=pdo SEARCH_BUILD=SPHINX2 EXCLUDE_GROUP="--exclude-group=Manticore"
+  - DRIVER=pdo SEARCH_BUILD=SPHINX3 EXCLUDE_GROUP="--exclude-group=Manticore"
   - DRIVER=pdo SEARCH_BUILD=MANTICORE
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ php:
   - 7.1
 
 env:
-  - DRIVER=mysqli SEARCH_BUILD=SPHINX2
-  - DRIVER=mysqli SEARCH_BUILD=SPHINX3
+  - DRIVER=mysqli SEARCH_BUILD=SPHINX2 EXCLUDE_GROUP="--exclude-group=Manitcore"
+  - DRIVER=mysqli SEARCH_BUILD=SPHINX3 EXCLUDE_GROUP="--exclude-group=Manitcore"
   - DRIVER=mysqli SEARCH_BUILD=MANTICORE
-  - DRIVER=pdo SEARCH_BUILD=SPHINX2
-  - DRIVER=pdo SEARCH_BUILD=SPHINX3
+  - DRIVER=pdo SEARCH_BUILD=SPHINX2 EXCLUDE_GROUP="--exclude-group=Manitcore"
+  - DRIVER=pdo SEARCH_BUILD=SPHINX3 EXCLUDE_GROUP="--exclude-group=Manitcore"
   - DRIVER=pdo SEARCH_BUILD=MANTICORE
 
 matrix:
@@ -32,9 +32,4 @@ before_script:
   - cd tests
   - $TRAVIS_BUILD_DIR/tests/run.sh
 
-script:
-  - if [ $SEARCH_BUILD == "MANTICORE" ]; then
-       phpunit --configuration travis/$DRIVER.phpunit.xml --coverage-text
-    else
-       phpunit --configuration travis/$DRIVER.phpunit.xml --exclude-group=Manticore --coverage-text
-    fi
+script: phpunit --configuration travis/$DRIVER.phpunit.xml --coverage-text $EXCLUDE_GROUP

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -101,12 +101,11 @@ class Helper
      */
     public function showTables( $index )
     {
-	$queryAppend = '';
-	if ( ! empty( $index ) ) {
-		$queryAppend = ' LIKE ' . $this->connection->quote($index);
-	}
-
-	return $this->query( 'SHOW TABLES' . $queryAppend );
+        $queryAppend = '';
+        if ( ! empty( $index ) ) {
+            queryAppend = ' LIKE ' . $this->connection->quote($index);
+        }
+        return $this->query( 'SHOW TABLES' . $queryAppend );
     }
 
     /**

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -99,9 +99,14 @@ class Helper
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
      */
-    public function showTables()
+    public function showTables( $index )
     {
-        return $this->query('SHOW TABLES');
+	$queryAppend = '';
+	if ( ! empty( $index ) ) {
+		$queryAppend = ' LIKE ' . $this->connection->quote($index);
+	}
+
+	return $this->query( 'SHOW TABLES' . $queryAppend );
     }
 
     /**

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -103,7 +103,7 @@ class Helper
     {
         $queryAppend = '';
         if ( ! empty( $index ) ) {
-            queryAppend = ' LIKE ' . $this->connection->quote($index);
+            $queryAppend = ' LIKE ' . $this->connection->quote($index);
         }
         return $this->query( 'SHOW TABLES' . $queryAppend );
     }

--- a/src/Percolate.php
+++ b/src/Percolate.php
@@ -1,0 +1,602 @@
+<?php
+
+namespace Foolz\SphinxQL;
+
+use Foolz\SphinxQL\Drivers\ConnectionInterface;
+use Foolz\SphinxQL\Exception\SphinxQLException;
+
+/**
+ * Query Builder class for Percolate Queries.
+ *
+ * ### INSERT ###
+ *
+ * $query = (new Percolate($conn))
+ *    ->insert('full text query terms', noEscape = false)       // Allowed only one insert per query (Symbol @ indicates field in sphinx.conf)
+ *                                                                 No escape tag cancels characters shielding (default on)
+ *    ->into('pq')                                              // Index for insert
+ *    ->tags(['tag1','tag2'])                                   // Adding tags. Can be array ['tag1','tag2'] or string delimited by coma
+ *    ->filter('price>3')                                       // Adding filter (Allowed only one)
+ *    ->execute();
+ *
+ *
+ * ### CALL PQ ###
+ *
+ *
+ * $query = (new Percolate($conn))
+ *    ->callPQ()
+ *    ->from('pq')                                              // Index for call pq
+ *    ->documents(['multiple documents', 'go this way'])        // see getDocuments function
+ *    ->options([                                               // See https://docs.manticoresearch.com/latest/html/searching/percolate_query.html#call-pq
+ *          Percolate::OPTION_VERBOSE => 1,
+ *          Percolate::OPTION_DOCS_JSON => 1
+ *    ])
+ *    ->execute();
+ *
+ *
+ */
+class Percolate
+{
+
+    /**
+     * @var ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * Documents for CALL PQ
+     *
+     * @var array|string
+     */
+    protected $documents;
+
+    /**
+     * Index name
+     *
+     * @var string
+     */
+    protected $index;
+
+    /**
+     * Insert query
+     *
+     * @var string
+     */
+    protected $query;
+
+    /**
+     * Options for CALL PQ
+     * @var array
+     */
+    protected $options = [self::OPTION_DOCS_JSON => 1];
+
+    /**
+     * @var array
+     */
+    protected $filters = [];
+
+    /**
+     * Query type (call | insert)
+     *
+     * @var string
+     */
+    protected $type = 'call';
+
+    /** INSERT STATEMENT  **/
+
+    protected $tags = [];
+
+    /**
+     * Throw exceptions flag.
+     * Activates if option OPTION_DOCS_JSON setted
+     *
+     * @var int
+     */
+    protected $throwExceptions = 0;
+    /**
+     * @var array
+     */
+    protected $escapeChars = [
+        '\\' => '\\\\',
+        '-' => '\\-',
+        '~' => '\\~',
+        '<' => '\\<',
+        '"' => '\\"',
+        "'" => "\\'",
+        '/' => '\\/',
+        '!' => '\\!'
+    ];
+
+    /** @var SphinxQL */
+    protected $sphinxQL;
+
+    /**
+     * CALL PQ option constants
+     */
+    const OPTION_DOCS_JSON = 'as docs_json';
+    const OPTION_DOCS = 'as docs';
+    const OPTION_VERBOSE = 'as verbose';
+    const OPTION_QUERY = 'as query';
+
+    /**
+     * @param ConnectionInterface $connection
+     */
+    public function __construct(ConnectionInterface $connection)
+    {
+        $this->connection = $connection;
+        $this->sphinxQL = new SphinxQL($this->connection);
+
+    }
+
+
+    /**
+     * Clear all fields after execute
+     */
+    private function clear()
+    {
+        $this->documents = null;
+        $this->index = null;
+        $this->query = null;
+        $this->options = [self::OPTION_DOCS_JSON => 1];
+        $this->type = 'call';
+        $this->filters = [];
+        $this->tags = [];
+    }
+
+    /**
+     * Analog into function
+     * Sets index name for query
+     *
+     * @param string $index
+     *
+     * @return $this
+     * @throws SphinxQLException
+     */
+    public function from($index)
+    {
+        if (empty($index)) {
+            throw new SphinxQLException('Index can\'t be empty');
+        }
+
+        $this->index = trim($index);
+        return $this;
+    }
+
+    /**
+     * Analog from function
+     * Sets index name for query
+     *
+     * @param string $index
+     *
+     * @return $this
+     * @throws SphinxQLException
+     */
+    public function into($index)
+    {
+        if (empty($index)) {
+            throw new SphinxQLException('Index can\'t be empty');
+        }
+        $this->index = trim($index);
+        return $this;
+    }
+
+    /**
+     * Replacing bad chars
+     *
+     * @param string $query
+     *
+     * @return string mixed
+     */
+    protected function escapeString($query)
+    {
+        return str_replace(
+            array_keys($this->escapeChars),
+            array_values($this->escapeChars),
+            $query);
+    }
+
+
+    /**
+     * @param $query
+     * @return mixed
+     */
+    protected function clearString($query)
+    {
+        return str_replace(
+            array_keys(array_merge($this->escapeChars, ['@' => ''])),
+            ['', '', '', '', '', '', '', '', '', ''],
+            $query);
+    }
+
+    /**
+     * Adding tags for insert query
+     *
+     * @param array|string $tags
+     *
+     * @return $this
+     */
+    public function tags($tags)
+    {
+        if (is_array($tags)) {
+            $tags = array_map([$this, 'escapeString'], $tags);
+            $tags = implode(',', $tags);
+        } else {
+            $tags = $this->escapeString($tags);
+        }
+        $this->tags = $tags;
+        return $this;
+    }
+
+    /**
+     * Add filter for insert query
+     *
+     * @param string $filter
+     * @return $this
+     *
+     * @throws SphinxQLException
+     */
+    public function filter($filter)
+    {
+        $filters = explode(',', $filter);
+        if (!empty($filters[1])) {
+            throw new SphinxQLException(
+                'Allow only one filter. If there is a comma in the text, it must be shielded');
+        }
+        $this->filters = $this->clearString($filter);
+        return $this;
+    }
+
+    /**
+     * Add insert query
+     *
+     * @param string $query
+     * @param bool $noEscape
+     *
+     * @return $this
+     * @throws SphinxQLException
+     */
+    public function insert($query, $noEscape = false)
+    {
+        $this->clear();
+
+        if (empty($query)) {
+            throw new SphinxQLException('Query can\'t be empty');
+        }
+        if (!$noEscape) {
+            $query = $this->escapeString($query);
+        }
+        $this->query = $query;
+        $this->type = 'insert';
+
+        return $this;
+    }
+
+    /**
+     * Generate array for insert, from setted class parameters
+     *
+     * @return array
+     */
+    private function generateInsert()
+    {
+        $insertArray = ['query' => $this->query];
+
+        if (!empty($this->tags)) {
+            $insertArray['tags'] = $this->tags;
+        }
+
+        if (!empty($this->filters)) {
+            $insertArray['filters'] = $this->filters;
+        }
+
+        return $insertArray;
+    }
+
+    /**
+     * Executs query and clear class parameters
+     *
+     * @return Drivers\ResultSetInterface
+     * @throws SphinxQLException
+     */
+    public function execute()
+    {
+
+        if ($this->type == 'insert') {
+            return $this->sphinxQL
+                ->insert()
+                ->into($this->index)
+                ->set($this->generateInsert())
+                ->execute();
+        }
+
+        return $this->sphinxQL
+            ->query("CALL PQ ('" .
+                $this->index . "', " . $this->getDocuments() . " " . $this->getOptions() . ")")
+            ->execute();
+    }
+
+    /**
+     * Set one option for CALL PQ
+     *
+     * @param string $key
+     * @param int $value
+     *
+     * @return $this
+     * @throws SphinxQLException
+     */
+    private function setOption($key, $value)
+    {
+        $value = intval($value);
+        if (!in_array($key, [
+            self::OPTION_DOCS_JSON,
+            self::OPTION_DOCS,
+            self::OPTION_VERBOSE,
+            self::OPTION_QUERY
+        ])) {
+            throw new SphinxQLException('Unknown option');
+        }
+
+        if ($value != 0 && $value != 1) {
+            throw new SphinxQLException('Option value can be only 1 or 0');
+        }
+
+        if ($key == self::OPTION_DOCS_JSON) {
+            $this->throwExceptions = 1;
+        }
+
+        $this->options[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Set document parameter for CALL PQ
+     *
+     * @param array|string $documents
+     * @return $this
+     * @throws SphinxQLException
+     */
+    public function documents($documents)
+    {
+        if (empty($documents)) {
+            throw new SphinxQLException('Document can\'t be empty');
+        }
+        $this->documents = $documents;
+
+        return $this;
+    }
+
+    /**
+     * Set options for CALL PQ
+     *
+     * @param array $options
+     * @return $this
+     * @throws SphinxQLException
+     */
+    public function options(array $options)
+    {
+        foreach ($options as $option => $value) {
+            $this->setOption($option, $value);
+        }
+        return $this;
+    }
+
+
+    /**
+     * Get and prepare options for CALL PQ
+     *
+     * @return string string
+     */
+    protected function getOptions()
+    {
+        $options = '';
+        if (!empty($this->options)) {
+            foreach ($this->options as $option => $value) {
+                $options .= ', ' . $value . ' ' . $option;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Check is array associative
+     * @param array $arr
+     * @return bool
+     */
+    private function isAssocArray(array $arr)
+    {
+        if (array() === $arr) {
+            return false;
+        }
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
+
+    /**
+     * Get documents for CALL PQ. If option setted JSON - returns json_encoded
+     *
+     * Now selection of supported types work automatically. You don't need set
+     * OPTION_DOCS_JSON to 1 or 0. But if you will set this option,
+     * automatically enables exceptions on unsupported types
+     *
+     *
+     * 1) If expect json = 0:
+     *      a) doc can be 'catch me'
+     *      b) doc can be multiple ['catch me if can','catch me']
+     *
+     * 2) If expect json = 1:
+     *      a) doc can be jsonOBJECT {"subject": "document about orange"}
+     *      b) docs can be jsonARRAY of jsonOBJECTS [{"subject": "document about orange"}, {"doc": "document about orange"}]
+     *      c) docs can be phpArray of jsonObjects ['{"subject": "document about orange"}', '{"doc": "document about orange"}']
+     *      d) doc can be associate array ['subject'=>'document about orange']
+     *      e) docs can be array of associate arrays [['subject'=>'document about orange'], ['doc'=>'document about orange']]
+     *
+     *
+     *
+     *
+     * @return string
+     * @throws SphinxQLException
+     */
+    protected function getDocuments()
+    {
+        if (!empty($this->documents)) {
+
+            if ($this->throwExceptions) {
+
+                if ($this->options[self::OPTION_DOCS_JSON]) {
+
+                    if (!is_array($this->documents)) {
+                        $json = $this->checkJson($this->documents);
+                        if (!$json) {
+                            throw new SphinxQLException('Documents must be in json format');
+                        }
+                    } else {
+                        if (!$this->isAssocArray($this->documents) && !is_array($this->documents[0])) {
+                            throw new SphinxQLException('Documents array must be associate');
+                        }
+                    }
+                }
+            }
+
+            if (is_array($this->documents)) {
+
+                // If input is phpArray with json like
+                // ->documents(['{"body": "body of doc 1", "title": "title of doc 1"}',
+                //             '{"subject": "subject of doc 3"}'])
+                //
+                // Checking first symbol of first array value. If [ or { - call checkJson
+
+                if (!empty($this->documents[0]) && !is_array($this->documents[0]) &&
+                    ($this->documents[0][0] == '[' || $this->documents[0][0] == '{')) {
+
+                    $json = $this->checkJson($this->documents);
+                    if ($json) {
+                        $this->options[self::OPTION_DOCS_JSON] = 1;
+                        return $json;
+                    }
+
+                } else {
+                    if (!$this->isAssocArray($this->documents)) {
+
+                        // if incoming single array like ['catch me if can', 'catch me']
+
+                        if (is_string($this->documents[0])) {
+                            $this->options[self::OPTION_DOCS_JSON] = 0;
+                            return '(' . $this->quoteString(implode('\', \'', $this->documents)) . ')';
+                        }
+
+                        // if doc is array of associate arrays [['foo'=>'bar'], ['foo1'=>'bar1']]
+                        if (!empty($this->documents[0]) && $this->isAssocArray($this->documents[0])) {
+                            $this->options[self::OPTION_DOCS_JSON] = 1;
+                            return $this->convertArrayForQuery($this->documents);
+                        }
+
+                    } else {
+                        if ($this->isAssocArray($this->documents)) {
+                            // Id doc is associate array ['foo'=>'bar']
+                            $this->options[self::OPTION_DOCS_JSON] = 1;
+                            return $this->quoteString(json_encode($this->documents));
+                        }
+                    }
+                }
+
+            } else {
+                if (is_string($this->documents)) {
+
+                    $json = $this->checkJson($this->documents);
+                    if ($json) {
+                        $this->options[self::OPTION_DOCS_JSON] = 1;
+                        return $json;
+                    }
+
+                    $this->options[self::OPTION_DOCS_JSON] = 0;
+                    return $this->quoteString($this->documents);
+                }
+            }
+        }
+        throw new SphinxQLException('Documents can\'t be empty');
+    }
+
+
+    /**
+     * Set type
+     *
+     * @return $this
+     */
+    public function callPQ()
+    {
+        $this->clear();
+        $this->type = 'call';
+        return $this;
+    }
+
+
+    /**
+     * Check string is valid json
+     *
+     * @param string $json
+     * @return bool
+     */
+    private function checkJson($json)
+    {
+        if (is_array($json)) {
+            if (is_array($json[0])) {
+                return false;
+            }
+            $return = [];
+            foreach ($json as $item) {
+                $return[] = $this->checkJson($item);
+            }
+            return '(' . implode(', ', $return) . ')';
+        }
+        $array = json_decode($json, true);
+
+        if (json_last_error() == JSON_ERROR_NONE) { // if json
+            if (!empty($array[0])) { // If docs is jsonARRAY of jsonOBJECTS
+                return $this->convertArrayForQuery($array);
+            }
+            // If docs is jsonOBJECT
+            return $this->quoteString($json);
+        }
+        return false;
+    }
+
+
+    /**
+     * Converts array of associate arrays to valid for query statement
+     * ('jsonOBJECT1', 'jsonOBJECT2' ...)
+     *
+     *
+     * @param array $array
+     * @return string
+     */
+    private function convertArrayForQuery(array $array)
+    {
+        $documents = [];
+        foreach ($array as $document) {
+            $documents[] = json_encode($document);
+        }
+
+        return '(' . $this->quoteString(implode('\', \'', $documents)) . ')';
+    }
+
+
+    /**
+     * Adding single quotes to string
+     *
+     * @param string $string
+     * @return string
+     */
+    private function quoteString($string)
+    {
+        return '\'' . $string . '\'';
+    }
+
+
+    /**
+     * Get last compiled query
+     *
+     * @return string
+     */
+    public function getLastQuery()
+    {
+        return $this->sphinxQL->getCompiled();
+    }
+}

--- a/tests/SphinxQL/HelperTest.php
+++ b/tests/SphinxQL/HelperTest.php
@@ -41,7 +41,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             array(array('Index' => 'rt', 'Type' => 'rt')),
-            $this->createHelper()->showTables()->execute()->getStored()
+            $this->createHelper()->showTables('rt')->execute()->getStored()
         );
     }
 

--- a/tests/SphinxQL/PercolateQueriesTest.php
+++ b/tests/SphinxQL/PercolateQueriesTest.php
@@ -1,0 +1,299 @@
+<?php
+
+use Foolz\SphinxQL\Exception\SphinxQLException;
+use Foolz\SphinxQL\Percolate;
+use Foolz\SphinxQL\Tests\TestUtil;
+use Foolz\SphinxQL\SphinxQL;
+/**
+ * @package Foolz\SphinxQL
+ * @author Vicent Valls
+ */
+class PercolateQueriesTest extends \PHPUnit\Framework\TestCase
+{
+    public static $conn = null;
+
+
+    public static function setUpBeforeClass()
+    {
+	    $conn = TestUtil::getConnectionDriver();
+	    $conn->setParam('port', 9307);
+	    self::$conn = $conn;
+
+        $sphinxQL = new SphinxQL(self::$conn);
+        $sphinxQL->query('TRUNCATE RTINDEX pq')->execute();
+    }
+
+
+    /**
+     * @dataProvider insertProvider
+     * @throws \Foolz\SphinxQL\Exception\SphinxQLException
+     */
+    public function testInsert($testNumber, $query, $index, $tags, $filter, $compiledQuery)
+    {
+
+        if ($testNumber == 2) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Index can\'t be empty');
+        }
+
+        if ($testNumber == 3) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Query can\'t be empty');
+        }
+
+        if ($testNumber == 10) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Allow only one filter. If there is a comma in the text, it must be shielded');
+        }
+
+
+        $percolate = new Percolate(self::$conn);
+        $percolate
+            ->insert($query)
+            ->into($index)
+            ->tags($tags)
+            ->filter($filter)
+            ->execute();
+
+        if (in_array($testNumber, [1, 4, 5, 6, 7, 8, 9, 11])) {
+            $this->assertEquals($compiledQuery, $percolate->getLastQuery());
+        }
+
+
+        //$this->markTestIncomplete(true);
+    }
+
+    public function insertProvider()
+    {
+
+        /**
+         * 1) Just insert
+         * 2) Insert empty index
+         * 3) Insert empty query
+         * 4) Insert with special symbols
+         * 5) Insert with tags as string without filter
+         * 6) Insert with tags as array of string without filter
+         * 7) Insert tags with special symbols
+         * 8) Insert with filter, withowt tags
+         * 9) Insert filter with special symbols
+         * 10) Insert two filters
+         * 11) Insert filter + tags
+         */
+
+
+        return [
+            [
+                1,
+                'full text query terms',
+                'pq',
+                null,
+                null,
+                "INSERT INTO pq (query) VALUES ('full text query terms')"
+            ],
+
+            [
+                2,
+                'full text query terms',
+                null,
+                null,
+                null,
+                null
+            ],
+
+            [
+                3,
+                null,
+                'pq',
+                null,
+                null,
+                null
+            ],
+
+            [
+                4,
+                '@doc (text) \' ^ $ " | ! ~ / = >< & - \query terms',
+                'pq',
+                null,
+                null,
+                'INSERT INTO pq (query) VALUES (\'@doc (text) \\\\\\\' ^ $ \\\\\\" | \\\\! \\\\~ \\\\/ = >\\\\< & \\\\- \\\\\\\\query terms\')'
+            ],
+
+            [
+                5,
+                '@subject match by field',
+                'pq',
+                'tag2,tag3',
+                'price>3',
+                "INSERT INTO pq (query, tags, filters) VALUES ('@subject match by field', 'tag2,tag3', 'price>3')"
+            ],
+
+            [
+                6,
+                '@subject orange',
+                'pq',
+                ['tag2', 'tag3'],
+                null,
+                "INSERT INTO pq (query, tags) VALUES ('@subject orange', 'tag2,tag3')"
+            ],
+
+            [
+                7,
+                '@subject orange',
+                'pq',
+                '@doc (text) \' ^ $ " | ! ~ / = >< & - \query terms',
+                null,
+                'INSERT INTO pq (query, tags) VALUES (\'@subject orange\', \'@doc (text) \\\\\\\' ^ $ \\\\\" | \\\\! \\\\~ \\\\/ = >\\\\< & \\\\- \\\\\\\\query terms\')'
+            ],
+
+            [
+                8,
+                'catch me',
+                'pq',
+                null,
+                'price>3',
+                'INSERT INTO pq (query, filters) VALUES (\'catch me\', \'price>3\')'
+            ],
+
+            [
+                9,
+                'catch me if can',
+                'pq',
+                null,
+                'p\@r\'ice>3',
+                'INSERT INTO pq (query, filters) VALUES (\'catch me if can\', \'price>3\')'
+            ],
+
+            [
+                10,
+                'catch me if can',
+                'pq',
+                null,
+                'price>3, secondFilter>0',
+                null
+            ],
+            [
+                11,
+                'orange|apple|cherry',
+                'pq',
+                ['tag2', 'tag3'],
+                'price>3',
+                "INSERT INTO pq (query, tags, filters) VALUES ('orange|apple|cherry', 'tag2,tag3', 'price>3')"
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider callPqProvider
+     * @throws \Foolz\SphinxQL\Exception\SphinxQLException
+     */
+
+    public function testPercolate($testNumber, $index, $documents, $options, $result)
+    {
+        if ($testNumber == 2) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Document can\'t be empty');
+
+        } elseif ($testNumber == 3) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Index can\'t be empty');
+
+        } elseif ($testNumber == 12) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Documents must be in json format');
+
+        } elseif ($testNumber == 13) {
+            $this->expectException(SphinxQLException::class);
+            $this->expectExceptionMessage('Documents array must be associate');
+
+        }
+
+        $query = (new Percolate(self::$conn))
+            ->callPQ()
+            ->from($index)
+            ->documents($documents)
+            ->options($options)
+            ->execute();
+
+
+        if (in_array($testNumber, [1, 4, 5, 6, 7, 8, 9, 11])) {
+            $query = $query->fetchAllAssoc();
+            $this->assertEquals($result[0], $query[0]['Query']);
+            $this->assertEquals($result[1], count($query));
+        }
+
+        if ($testNumber == 10) {
+            $query = $query->fetchAllAssoc();
+            $this->assertEquals($result[0], $query[0]['UID']);
+            $this->assertEquals($result[1], count($query));
+        }
+
+    }
+
+    public function callPqProvider()
+    {
+        /**
+         * 1) Call PQ
+         * 2) Document empty
+         * 3) Index empty
+         * 4) Documents array of string
+         * 5) Documents associate array
+         * 6) Documents array of associate array
+         * 7) Documents jsonObject
+         * 8) Documents jsonArray of jsonObject
+         * 9) Documents phpArray of jsonObject
+         * 10) Option OPTION_QUERY
+         * 11) Option OPTION_DOCS
+         * Throws OPTION_DOCS_JSON
+         * 12) Not json string
+         * 13) Not array with non json string
+         */
+
+
+        return [
+            [1, 'pq', 'full text query terms', [Percolate::OPTION_QUERY => 1], ['full text query terms', 2]],
+            [2, 'pq', '', [], null],
+            [3, '', 'full', [], null],
+            [
+                4,
+                'pq',
+                ['query terms', 'full text query terms'],
+                [Percolate::OPTION_QUERY => 1],
+                ['full text query terms', 2]
+            ],
+            [5, 'pq', ['subject' => 'document about orange'], [Percolate::OPTION_QUERY => 1], ['@subject orange', 2]],
+            [
+                6,
+                'pq',
+                [['subject' => 'document about orange'], ['subject' => 'match by field', 'price' => 1]],
+                [Percolate::OPTION_QUERY => 1],
+                ['@subject orange', 2]
+            ],
+            [7, 'pq', '{"subject":"document about orange"}', [Percolate::OPTION_QUERY => 1], ['@subject orange', 2]],
+            [
+                8,
+                'pq',
+                '[{"subject":"document about orange"}, {"subject":"match by field","price":10}]',
+                [Percolate::OPTION_QUERY => 1],
+                ['@subject match by field', 3]
+            ],
+            [
+                9,
+                'pq',
+                ['{"subject":"document about orange"}', '{"subject":"match by field","price":10}'],
+                [Percolate::OPTION_QUERY => 1],
+                ['@subject match by field', 3]
+            ],
+            [10, 'pq', 'full text query terms', [Percolate::OPTION_QUERY => 0], [1, 2]],
+            [
+                11,
+                'pq',
+                ['{"subject":"document about orange"}', '{"subject":"match by field","price":10}'],
+                [Percolate::OPTION_QUERY => 1, Percolate::OPTION_DOCS => 1],
+                ['@subject match by field', 3]
+            ],
+            [12, 'pq', 'full text query terms', [Percolate::OPTION_DOCS_JSON => 1], null],
+            [13, 'pq', ['full text query terms','full text'], [Percolate::OPTION_DOCS_JSON => 1], null],
+        ];
+    }
+
+}

--- a/tests/SphinxQL/PercolateQueriesTest.php
+++ b/tests/SphinxQL/PercolateQueriesTest.php
@@ -5,6 +5,7 @@ use Foolz\SphinxQL\Percolate;
 use Foolz\SphinxQL\Tests\TestUtil;
 use Foolz\SphinxQL\SphinxQL;
 /**
+ * @group Manticore
  * @package Foolz\SphinxQL
  * @author Vicent Valls
  */

--- a/tests/SphinxQL/PercolateQueriesTest.php
+++ b/tests/SphinxQL/PercolateQueriesTest.php
@@ -42,12 +42,6 @@ class PercolateQueriesTest extends \PHPUnit\Framework\TestCase
             $this->expectExceptionMessage('Query can\'t be empty');
         }
 
-        if ($testNumber == 10) {
-            $this->expectException(SphinxQLException::class);
-            $this->expectExceptionMessage('Allow only one filter. If there is a comma in the text, it must be shielded');
-        }
-
-
         $percolate = new Percolate(self::$conn);
         $percolate
             ->insert($query)
@@ -164,14 +158,6 @@ class PercolateQueriesTest extends \PHPUnit\Framework\TestCase
                 'INSERT INTO pq (query, filters) VALUES (\'catch me if can\', \'price>3\')'
             ],
 
-            [
-                10,
-                'catch me if can',
-                'pq',
-                null,
-                'price>3, secondFilter>0',
-                null
-            ],
             [
                 11,
                 'orange|apple|cherry',

--- a/tests/manticore.conf
+++ b/tests/manticore.conf
@@ -1,0 +1,334 @@
+# Custom sphinx.conf for unit testing.
+# ./configure --prefix=/usr/local/sphinx
+# make && make install
+# /usr/local/sphinx/bin/searchd --config=/vagrant/sphinxql/test/sphinx.conf
+
+
+#
+# Sphinx configuration file sample
+#
+# WARNING! While this sample file mentions all available options,
+# it contains (very) short helper descriptions only. Please refer to
+# doc/sphinx.html for details.
+#
+
+#############################################################################
+## index definition
+#############################################################################
+
+# realtime index example
+#
+# you can run INSERT, REPLACE, and DELETE on this index on the fly
+# using MySQL protocol (see 'listen' directive below)
+index rt
+{
+	# 'rt' index type must be specified to use RT index
+	type			= rt
+
+	# index files path and file name, without extension
+	# mandatory, path must be writable, extensions will be auto-appended
+	path			= data/rt
+
+	# RAM chunk size limit
+	# RT index will keep at most this much data in RAM, then flush to disk
+	# optional, default is 32M
+	#
+	# rt_mem_limit		= 512M
+
+	# full-text field declaration
+	# multi-value, mandatory
+	rt_field		= title
+	rt_field		= content
+
+	# unsigned integer attribute declaration
+	# multi-value (an arbitrary number of attributes is allowed), optional
+	# declares an unsigned 32-bit attribute
+	rt_attr_uint		= gid
+
+	# RT indexes currently support the following attribute types:
+	# uint, bigint, float, timestamp, string
+	#
+	# rt_attr_bigint		= guid
+	# rt_attr_float		= gpa
+	# rt_attr_timestamp	= ts_added
+	# rt_attr_string		= author
+}
+
+# Percolate index example https://docs.manticoresearch.com/latest/html/searching/percolate_query.html
+
+index pq {
+    type = percolate
+    path = data/pq
+    rt_field = doc
+    rt_field = subject
+    rt_attr_uint = price
+}
+
+#############################################################################
+## indexer settings
+#############################################################################
+
+indexer
+{
+	# memory limit, in bytes, kiloytes (16384K) or megabytes (256M)
+	# optional, default is 32M, max is 2047M, recommended is 256M to 1024M
+	mem_limit		= 32M
+
+	# maximum IO calls per second (for I/O throttling)
+	# optional, default is 0 (unlimited)
+	#
+	# max_iops		= 40
+
+
+	# maximum IO call size, bytes (for I/O throttling)
+	# optional, default is 0 (unlimited)
+	#
+	# max_iosize		= 1048576
+
+
+	# maximum xmlpipe2 field length, bytes
+	# optional, default is 2M
+	#
+	# max_xmlpipe2_field	= 4M
+
+
+	# write buffer size, bytes
+	# several (currently up to 4) buffers will be allocated
+	# write buffers are allocated in addition to mem_limit
+	# optional, default is 1M
+	#
+	# write_buffer		= 1M
+
+
+	# maximum file field adaptive buffer size
+	# optional, default is 8M, minimum is 1M
+	#
+	# max_file_field_buffer	= 32M
+}
+
+#############################################################################
+## searchd settings
+#############################################################################
+
+searchd
+{
+	# [hostname:]port[:protocol], or /unix/socket/path to listen on
+	# known protocols are 'sphinx' (SphinxAPI) and 'mysql41' (SphinxQL)
+	#
+	# multi-value, multiple listen points are allowed
+	# optional, defaults are 9312:sphinx and 9306:mysql41, as below
+	#
+	# listen			= 127.0.0.1
+	# listen			= 192.168.0.1:9312
+	# listen			= 9312
+	# listen			= /var/run/searchd.sock
+	listen			= 9312
+	#listen			= 9306:mysql41
+	listen			= 9307:mysql41
+
+	# log file, searchd run info is logged here
+	# optional, default is 'searchd.log'
+	#log			= log/searchd.log
+
+	# query log file, all search queries are logged here
+	# optional, default is empty (do not log queries)
+	#query_log		= log/query.log
+
+	# client read timeout, seconds
+	# optional, default is 5
+	read_timeout		= 5
+
+	# request timeout, seconds
+	# optional, default is 5 minutes
+	client_timeout		= 300
+
+	# maximum amount of children to fork (concurrent searches to run)
+	# optional, default is 0 (unlimited)
+	max_children		= 30
+
+	# PID file, searchd process ID file name
+	# mandatory
+	pid_file		= searchd.pid
+
+	# seamless rotate, prevents rotate stalls if precaching huge datasets
+	# optional, default is 1
+	seamless_rotate		= 1
+
+	# whether to forcibly preopen all indexes on startup
+	# optional, default is 1 (preopen everything)
+	preopen_indexes		= 1
+
+	# whether to unlink .old index copies on succesful rotation.
+	# optional, default is 1 (do unlink)
+	unlink_old		= 1
+
+	# attribute updates periodic flush timeout, seconds
+	# updates will be automatically dumped to disk this frequently
+	# optional, default is 0 (disable periodic flush)
+	#
+	# attr_flush_period	= 900
+
+
+	# instance-wide ondisk_dict defaults (per-index value take precedence)
+	# optional, default is 0 (precache all dictionaries in RAM)
+	#
+	# ondisk_dict_default	= 1
+
+
+	# MVA updates pool size
+	# shared between all instances of searchd, disables attr flushes!
+	# optional, default size is 1M
+	mva_updates_pool	= 1M
+
+	# max allowed network packet size
+	# limits both query packets from clients, and responses from agents
+	# optional, default size is 8M
+	max_packet_size		= 8M
+
+	# crash log path
+	# searchd will (try to) log crashed query to 'crash_log_path.PID' file
+	# optional, default is empty (do not create crash logs)
+	#
+	# crash_log_path		= /usr/local/sphinx/var/log/crash
+
+
+	# max allowed per-query filter count
+	# optional, default is 256
+	max_filters		= 256
+
+	# max allowed per-filter values count
+	# optional, default is 4096
+	max_filter_values	= 4096
+
+
+	# socket listen queue length
+	# optional, default is 5
+	#
+	# listen_backlog		= 5
+
+
+	# per-keyword read buffer size
+	# optional, default is 256K
+	#
+	# read_buffer		= 256K
+
+
+	# unhinted read size (currently used when reading hits)
+	# optional, default is 32K
+	#
+	# read_unhinted		= 32K
+
+
+	# max allowed per-batch query count (aka multi-query count)
+	# optional, default is 32
+	max_batch_queries	= 32
+
+
+	# max common subtree document cache size, per-query
+	# optional, default is 0 (disable subtree optimization)
+	#
+	# subtree_docs_cache	= 4M
+
+
+	# max common subtree hit cache size, per-query
+	# optional, default is 0 (disable subtree optimization)
+	#
+	# subtree_hits_cache	= 8M
+
+
+	# multi-processing mode (MPM)
+	# known values are none, fork, prefork, and threads
+	# optional, default is fork
+	#
+	workers			= threads # for RT to work
+
+
+	# max threads to create for searching local parts of a distributed index
+	# optional, default is 0, which means disable multi-threaded searching
+	# should work with all MPMs (ie. does NOT require workers=threads)
+	#
+	# dist_threads		= 4
+
+
+	# binlog files path; use empty string to disable binlog
+	# optional, default is build-time configured data directory
+	#
+	 binlog_path		= # disable logging
+	# binlog_path		= /usr/local/sphinx/var/data # binlog.001 etc will be created there
+
+
+	# binlog flush/sync mode
+	# 0 means flush and sync every second
+	# 1 means flush and sync every transaction
+	# 2 means flush every transaction, sync every second
+	# optional, default is 2
+	#
+	# binlog_flush		= 2
+
+
+	# binlog per-file size limit
+	# optional, default is 128M, 0 means no limit
+	#
+	# binlog_max_log_size	= 256M
+
+
+	# per-thread stack size, only affects workers=threads mode
+	# optional, default is 64K
+	#
+	# thread_stack			= 128K
+
+
+	# per-keyword expansion limit (for dict=keywords prefix searches)
+	# optional, default is 0 (no limit)
+	#
+	# expansion_limit		= 1000
+
+
+	# RT RAM chunks flush period
+	# optional, default is 0 (no periodic flush)
+	#
+	# rt_flush_period		= 900
+
+
+	# query log file format
+	# optional, known values are plain and sphinxql, default is plain
+	#
+	# query_log_format		= sphinxql
+
+
+	# version string returned to MySQL network protocol clients
+	# optional, default is empty (use Sphinx version)
+	#
+	# mysql_version_string	= 5.0.37
+
+
+	# trusted plugin directory
+	# optional, default is empty (disable UDFs)
+	#
+	# plugin_dir			= /usr/local/sphinx/lib
+
+
+	# default server-wide collation
+	# optional, default is libc_ci
+	#
+	# collation_server		= utf8_general_ci
+
+
+	# server-wide locale for libc based collations
+	# optional, default is C
+	#
+	# collation_libc_locale	= ru_RU.UTF-8
+
+
+	# threaded server watchdog (only used in workers=threads mode)
+	# optional, values are 0 and 1, default is 1 (watchdog on)
+	#
+	# watchdog				= 1
+}
+
+common
+{
+	plugin_dir	= data
+}
+
+# --eof--

--- a/tests/ms_test_udf.c
+++ b/tests/ms_test_udf.c
@@ -1,0 +1,15 @@
+//------------- see sphinxudf.h -------------//
+#define SPH_UDF_VERSION 9
+typedef struct st_sphinx_udf_args SPH_UDF_ARGS;
+typedef struct st_sphinx_udf_init SPH_UDF_INIT;
+//-------------------------------------------//
+
+int test_udf_ver()
+{
+    return SPH_UDF_VERSION;
+}
+
+int my_udf(SPH_UDF_INIT* init, SPH_UDF_ARGS* args, char* error_flag)
+{
+    return 42;
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,6 +14,6 @@ case $SEARCH_BUILD in
   MANTICORE)
     WORK=$HOME/search
     gcc -shared -o data/test_udf.so ms_test_udf.c
-    $WORK/usr/bin/searchd -c sphinx.conf
+    $WORK/usr/bin/searchd -c manticore.conf
     ;;
 esac


### PR DESCRIPTION
The PR contains a new class Percolate that:

* perform CALL PQ 
* perform INSERT in a percolate index (this can be done with regular INSERT as well)

The PQ is a new feature in Manticore that stored queries in a new index type - percolate -  and can test documents if they match the stored queries.

Also added a parameter for Helper::ShowTables to allow performing ``SHOW TABLES LIKE 'filter'`` (this is available in Sphinx too) .  This is also needed to change in the Helper unit test for the show tables test, as for Percolate unit test a different `.conf` should be used to include a ``pq`` index as well.  In Travis when Manticore is tested, it should be used the `manticore.conf` instead of `sphinx.conf`.
