### PR TITLE
PHPDoc added @throws

### DIFF
--- a/src/Drivers/ConnectionBase.php
+++ b/src/Drivers/ConnectionBase.php
@@ -135,6 +135,7 @@ abstract class ConnectionBase implements ConnectionInterface
      * Closes and unset the connection to the Sphinx server.
      *
      * @return $this
+     * @throws ConnectionException
      */
     public function close()
     {

--- a/src/Drivers/ConnectionInterface.php
+++ b/src/Drivers/ConnectionInterface.php
@@ -2,6 +2,7 @@
 
 namespace Foolz\SphinxQL\Drivers;
 
+use Foolz\SphinxQL\Exception\ConnectionException;
 use Foolz\SphinxQL\Exception\DatabaseException;
 use Foolz\SphinxQL\Exception\SphinxQLException;
 use Foolz\SphinxQL\Expression;
@@ -15,6 +16,7 @@ interface ConnectionInterface
      *
      * @return ResultSetInterface The result array or number of rows affected
      * @throws DatabaseException If the executed query produced an error
+     * @throws ConnectionException
      */
     public function query($query);
 
@@ -26,6 +28,7 @@ interface ConnectionInterface
      * @return MultiResultSetInterface The result array
      * @throws DatabaseException In case a query throws an error
      * @throws SphinxQLException In case the array passed is empty
+     * @throws ConnectionException
      */
     public function multiQuery(array $queue);
 
@@ -36,6 +39,7 @@ interface ConnectionInterface
      *
      * @return string The escaped string
      * @throws DatabaseException If an error was encountered during server-side escape
+     * @throws ConnectionException
      */
     public function escape($value);
 
@@ -46,6 +50,8 @@ interface ConnectionInterface
      *      to leave it untouched
      *
      * @return Expression|string|int The untouched Expression or the quoted string
+     * @throws DatabaseException
+     * @throws ConnectionException
      */
     public function quote($value);
 
@@ -55,6 +61,8 @@ interface ConnectionInterface
      * @param array $array The array of elements to quote
      *
      * @return array The array of quotes elements
+     * @throws DatabaseException
+     * @throws ConnectionException
      */
     public function quoteArr(array $array = array());
 }

--- a/src/Drivers/MultiResultSet.php
+++ b/src/Drivers/MultiResultSet.php
@@ -46,6 +46,7 @@ class MultiResultSet implements MultiResultSetInterface
 
     /**
      * @inheritdoc
+     * @throws DatabaseException
      */
     public function getStored()
     {
@@ -56,6 +57,7 @@ class MultiResultSet implements MultiResultSetInterface
 
     /**
      * @inheritdoc
+     * @throws DatabaseException
      */
     public function offsetExists($offset)
     {
@@ -66,6 +68,7 @@ class MultiResultSet implements MultiResultSetInterface
 
     /**
      * @inheritdoc
+     * @throws DatabaseException
      */
     public function offsetGet($offset)
     {
@@ -121,6 +124,7 @@ class MultiResultSet implements MultiResultSetInterface
 
     /**
      * @inheritdoc
+     * @throws DatabaseException
      */
     public function count()
     {

--- a/src/Drivers/Mysqli/Connection.php
+++ b/src/Drivers/Mysqli/Connection.php
@@ -66,6 +66,7 @@ class Connection extends ConnectionBase
      * Pings the Sphinx server.
      *
      * @return bool True if connected, false otherwise
+     * @throws ConnectionException
      */
     public function ping()
     {

--- a/src/Drivers/ResultSet.php
+++ b/src/Drivers/ResultSet.php
@@ -94,6 +94,7 @@ class ResultSet implements ResultSetInterface
 
     /**
      * @inheritdoc
+     * @throws ResultSetException
      */
     public function offsetGet($offset)
     {

--- a/src/Facet.php
+++ b/src/Facet.php
@@ -316,6 +316,7 @@ class Facet
      * Get String with SQL facet
      *
      * @return string
+     * @throws SphinxQLException
      */
     public function getFacet()
     {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -98,6 +98,8 @@ class Helper
      * Runs query: SHOW TABLES
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      */
     public function showTables( $index )
     {
@@ -126,6 +128,8 @@ class Helper
      * @param bool   $global True if the variable should be global, false otherwise
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      */
     public function setVariable($name, $value, $global = false)
     {
@@ -160,6 +164,8 @@ class Helper
      * @param array        $options Associative array of additional options
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      */
     public function callSnippets($data, $index, $query, $options = array())
     {
@@ -190,6 +196,8 @@ class Helper
      * @param null|string $hits
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      */
     public function callKeywords($text, $index, $hits = null)
     {
@@ -221,6 +229,8 @@ class Helper
      * @param string $so_name
      *
      * @return SphinxQL A SphinxQL object ready to be ->execute();
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      */
     public function createFunction($udf_name, $returns, $so_name)
     {

--- a/src/Percolate.php
+++ b/src/Percolate.php
@@ -289,6 +289,8 @@ class Percolate
      * Executs query and clear class parameters
      *
      * @return Drivers\ResultSetInterface
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      * @throws SphinxQLException
      */
     public function execute()

--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -5,6 +5,8 @@ namespace Foolz\SphinxQL;
 use Foolz\SphinxQL\Drivers\ConnectionInterface;
 use Foolz\SphinxQL\Drivers\MultiResultSetInterface;
 use Foolz\SphinxQL\Drivers\ResultSetInterface;
+use Foolz\SphinxQL\Exception\ConnectionException;
+use Foolz\SphinxQL\Exception\DatabaseException;
 use Foolz\SphinxQL\Exception\SphinxQLException;
 
 /**
@@ -253,6 +255,9 @@ class SphinxQL
      * Runs the query built
      *
      * @return ResultSetInterface The result of the query
+     * @throws DatabaseException
+     * @throws ConnectionException
+     * @throws SphinxQLException
      */
     public function execute()
     {
@@ -265,6 +270,8 @@ class SphinxQL
      *
      * @return MultiResultSetInterface The array of results
      * @throws SphinxQLException In case no query is in queue
+     * @throws Exception\DatabaseException
+     * @throws ConnectionException
      */
     public function executeBatch()
     {
@@ -364,6 +371,8 @@ class SphinxQL
 
     /**
      * Begins transaction
+     * @throws DatabaseException
+     * @throws ConnectionException
      */
     public function transactionBegin()
     {
@@ -372,6 +381,8 @@ class SphinxQL
 
     /**
      * Commits transaction
+     * @throws DatabaseException
+     * @throws ConnectionException
      */
     public function transactionCommit()
     {
@@ -380,6 +391,8 @@ class SphinxQL
 
     /**
      * Rollbacks transaction
+     * @throws DatabaseException
+     * @throws ConnectionException
      */
     public function transactionRollback()
     {
@@ -390,6 +403,9 @@ class SphinxQL
      * Runs the compile function
      *
      * @return $this
+     * @throws ConnectionException
+     * @throws DatabaseException
+     * @throws SphinxQLException
      */
     public function compile()
     {
@@ -430,6 +446,8 @@ class SphinxQL
      * Used by: SELECT, DELETE, UPDATE
      *
      * @return string The compiled MATCH
+     * @throws Exception\ConnectionException
+     * @throws Exception\DatabaseException
      */
     public function compileMatch()
     {
@@ -480,6 +498,8 @@ class SphinxQL
      * Used by: SELECT, DELETE, UPDATE
      *
      * @return string The compiled WHERE
+     * @throws ConnectionException
+     * @throws DatabaseException
      */
     public function compileWhere()
     {
@@ -505,6 +525,8 @@ class SphinxQL
      * @param array $filter
      *
      * @return string
+     * @throws ConnectionException
+     * @throws DatabaseException
      */
     public function compileFilterCondition($filter)
     {
@@ -539,6 +561,9 @@ class SphinxQL
      * Compiles the statements for SELECT
      *
      * @return $this
+     * @throws ConnectionException
+     * @throws DatabaseException
+     * @throws SphinxQLException
      */
     public function compileSelect()
     {
@@ -680,6 +705,8 @@ class SphinxQL
      * Compiles the statements for INSERT or REPLACE
      *
      * @return $this
+     * @throws ConnectionException
+     * @throws DatabaseException
      */
     public function compileInsert()
     {
@@ -718,6 +745,8 @@ class SphinxQL
      * Compiles the statements for UPDATE
      *
      * @return $this
+     * @throws ConnectionException
+     * @throws DatabaseException
      */
     public function compileUpdate()
     {
@@ -758,6 +787,8 @@ class SphinxQL
      * Compiles the statements for DELETE
      *
      * @return $this
+     * @throws ConnectionException
+     * @throws DatabaseException
      */
     public function compileDelete()
     {


### PR DESCRIPTION
@Throw tags was only found on the function doing the doing the throwing.

But as the functions using thous function, didn't catch them, they also throws them by letting them pass.

By adding @throw tags to all places where phpstorm sugested it, users can now see what Exception they expects, and have there editor sugest what catch-statments or @throw tags they should add.