### PR TITLE
Possible fix for #191 - PDOException's $code may be a string instead of an int

### DIFF
--- a/src/Drivers/Pdo/Connection.php
+++ b/src/Drivers/Pdo/Connection.php
@@ -25,7 +25,8 @@ class Connection extends ConnectionBase
         try {
             $statement->execute();
         } catch (PDOException $exception) {
-            throw new DatabaseException($exception->getMessage() . ' [' . $query . ']', $exception->getCode(), $exception);
+            throw new DatabaseException('[' . $exception->getCode() . '] ' . $exception->getMessage() . ' [' . $query . ']',
+                (int)$exception->getCode(), $exception);
         }
 
         return new ResultSet(new ResultSetAdapter($statement));


### PR DESCRIPTION
`TypeError: Exception::__construct(): Argument #2 ($code) must be of type int, string given in vendor/foolz/sphinxql-query-builder/src/Drivers/Pdo/Connection.php:28`

See also https://bugs.php.net/bug.php?id=51742. We've been experiencing this error occasionally and because of the incorrect handling, we weren't able to find out what our actual database errors are. This PR closes #191.