### PR TITLE
add DISTINCT in FACET for manticoresearch 4.x

### DIFF
--- a/src/Facet.php
+++ b/src/Facet.php
@@ -329,4 +329,14 @@ class Facet
     {
         return $this->compileFacet()->query;
     }
+
+    /**
+     * @param $distinct
+     * @return Facet
+     */
+    public function distinct($distinct)
+    {
+        $this->distinct_by = $distinct;
+        return $this;
+    }
 }

--- a/tests/SphinxQL/FacetTest.php
+++ b/tests/SphinxQL/FacetTest.php
@@ -142,13 +142,13 @@ class FacetTest  extends PHPUnit_Framework_TestCase
         $this->assertEquals('FACET gid, title ORDER BY COUNT(*) DESC LIMIT 5, 5', $facet);
     }
 
-	public function testDistinct()
-	{
-		$facet = Facet::create(self::$conn)
-			->facet(array('gid', 'title'))
-			->distinct('title')
-			->getFacet();
+    public function testDistinct()
+    {
+        $facet = Facet::create(self::$conn)
+            ->facet(array('gid', 'title'))
+            ->distinct('title')
+            ->getFacet();
 
-		$this->assertEquals('FACET gid, title DISTINCT title', $facet);
-	}
+        $this->assertEquals('FACET gid, title DISTINCT title', $facet);
+    }
 }

--- a/tests/SphinxQL/FacetTest.php
+++ b/tests/SphinxQL/FacetTest.php
@@ -141,4 +141,14 @@ class FacetTest  extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('FACET gid, title ORDER BY COUNT(*) DESC LIMIT 5, 5', $facet);
     }
+
+	public function testDistinct()
+	{
+		$facet = Facet::create(self::$conn)
+			->facet(array('gid', 'title'))
+			->distinct('title')
+			->getFacet();
+
+		$this->assertEquals('FACET gid, title DISTINCT title', $facet);
+	}
 }


### PR DESCRIPTION
In manticoresearch you can return faceting without duplicates: https://manual.manticoresearch.com/Searching/Faceted_search#Faceting-by-aggregation-over-another-attribute