### PR TITLE
Deprecated: Foolz\SphinxQL\SphinxQL::__construct(): Implicitly markin…

### DIFF
--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -219,7 +219,7 @@ class SphinxQL
     /**
      * @param ConnectionInterface|null $connection
      */
-    public function __construct(ConnectionInterface $connection = null)
+    public function __construct(?ConnectionInterface $connection = null)
     {
         $this->connection = $connection;
     }


### PR DESCRIPTION
```Deprecated: Foolz\SphinxQL\SphinxQL::__construct(): Implicitly marking parameter $connection as nullable is deprecated, the explicit nullable type must be used instead in vendor/foolz/sphinxql-query-builder/src/SphinxQL.php on line 222```