### PR TITLE
Deprecated: Foolz\SphinxQL\SphinxQL::enqueue(): Implicitly marking pa…

### DIFF
--- a/src/SphinxQL.php
+++ b/src/SphinxQL.php
@@ -304,7 +304,7 @@ class SphinxQL
      *
      * @return SphinxQL A new SphinxQL object with the current object referenced
      */
-    public function enqueue(SphinxQL $next = null)
+    public function enqueue(?SphinxQL $next = null)
     {
         if ($next === null) {
             $next = new static($this->getConnection());


### PR DESCRIPTION
```
Deprecated: Foolz\SphinxQL\SphinxQL::enqueue(): Implicitly marking parameter $next as nullable is deprecated, the explicit nullable type must be used instead in /vendor/foolz/sphinxql-query-builder/src/SphinxQL.php on line 307
```